### PR TITLE
Always save the buffer, even if it is unmodified

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -677,7 +677,7 @@ class TextBuffer
 
   # Public: Save the buffer.
   save: ->
-    @saveAs(@getPath()) if @isModified()
+    @saveAs(@getPath())
 
   # Public: Save the buffer at a specific path.
   #


### PR DESCRIPTION
There are some unexpected side effects when the buffer isn't saved because it is unmodified. 
- People expect whitespace to be removed when they press `cmd-s`. But if the buffer wasn't changed it won't be because the whitespace package listens for the `will-be-saved` event.
- People use `cmd-s` to update the file's modified date. They rely on this functionality to trigger scripts.

Also, there doesn't seem to be much downside to always saving.
