### PR TITLE
To prevent overriding the users settings, look and see if the user wants to allow softTabs

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -913,6 +913,7 @@ class TextBuffer
   #
   # Returns a {Boolean},
   usesSoftTabs: ->
+    return false unless atom.config.get("editor.softTabs")
     for row in [0..@getLastRow()]
       if match = @lineForRow(row).match(/^\s/)
         return match[0][0] != '\t'


### PR DESCRIPTION
Just because a file is a mix of tabs and spaces doesn't mean the user wants to use softTabs. As a result, text-buffer should first look at the editor.softTabs preferance before determining what to use to prevent overriding the end user. This addresses [Issue 11](https://github.com/atom/text-buffer/issues/11).
