### PR TITLE
Make inside markers end-point exclusive with respect to text insertions

### DIFF
--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -554,14 +554,37 @@ describe "Marker", ->
           expect(marker.getRange()).toEqual [[0, 6], [0, 9]]
           expect(marker.isValid()).toBe true
 
+    describe "when a change starts and ends at a marker's start position", ->
+      it "interprets the change as being inside the marker for all invalidation strategies except 'inside'", ->
+        buffer.insert([0, 6], "ABC")
+
+        for marker in difference(allStrategies, [insideMarker, touchMarker])
+          expect(marker.getRange()).toEqual [[0, 6], [0, 12]]
+          expect(marker.isValid()).toBe true
+
+        expect(insideMarker.getRange()).toEqual [[0, 9], [0, 12]]
+        expect(insideMarker.isValid()).toBe true
+
+        expect(touchMarker.getRange()).toEqual [[0, 6], [0, 12]]
+        expect(touchMarker.isValid()).toBe false
+
+        buffer.undo()
+
+        for marker in allStrategies
+          expect(marker.getRange()).toEqual [[0, 6], [0, 9]]
+          expect(marker.isValid()).toBe true
+
     describe "when a change starts at a marker's end position", ->
       describe "when the change is an insertion", ->
-        it "interprets the change as being inside the marker for all invalidation strategies", ->
+        it "interprets the change as being inside the marker for all invalidation strategies except 'inside'", ->
           buffer.setTextInRange([[0, 9], [0, 9]], "ABC")
 
-          for marker in difference(allStrategies, [touchMarker])
+          for marker in difference(allStrategies, [insideMarker, touchMarker])
             expect(marker.getRange()).toEqual [[0, 6], [0, 12]]
             expect(marker.isValid()).toBe true
+
+          expect(insideMarker.getRange()).toEqual [[0, 6], [0, 9]]
+          expect(insideMarker.isValid()).toBe true
 
           expect(touchMarker.getRange()).toEqual [[0, 6], [0, 12]]
           expect(touchMarker.isValid()).toBe false

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -389,9 +389,10 @@ class Marker
 
     newMarkerRange = @range.copy()
 
-    changePrecedesMarkerStart = oldRange.end.isLessThan(markerStart) or (not @hasTail() and oldRange.end.isLessThanOrEqual(markerStart))
+    exclusive = not @hasTail() or @getInvalidationStrategy() is 'inside'
+    changePrecedesMarkerStart = oldRange.end.isLessThan(markerStart) or (exclusive and oldRange.end.isLessThanOrEqual(markerStart))
     changeSurroundsMarkerStart = not changePrecedesMarkerStart and oldRange.start.isLessThan(markerStart)
-    changePrecedesMarkerEnd = oldRange.end.isLessThanOrEqual(markerEnd)
+    changePrecedesMarkerEnd = changePrecedesMarkerStart or oldRange.end.isLessThan(markerEnd) or (not exclusive and oldRange.end.isLessThanOrEqual(markerEnd))
     changeSurroundsMarkerEnd = not changePrecedesMarkerEnd and oldRange.start.isLessThan(markerEnd)
 
     if changePrecedesMarkerStart


### PR DESCRIPTION
Since 'inside' markers are invalidated when a change occurs inside them, we want to avoid invalidation if possible by assuming that insertions at an 'inside' marker's start or end points are outside the marker.

/cc @kevinsawicki 
