### PR TITLE
Ability to pass file object to TextBuffer and update pathwatcher for mor...

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "emissary": "^1.0.0",
     "event-kit": "^0.8.1",
     "fs-plus": "^2.0.0",
-    "grim": "1.0.0",
+    "grim": "^1",
     "interval-skip-list": "^2.0.0",
     "pathwatcher": "^3.0.0",
     "q": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "delegato": "^1.0.0",
     "atom-diff": "^2",
     "emissary": "^1.0.0",
-    "event-kit": "^0.8.1",
+    "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",
     "grim": "^1",
     "interval-skip-list": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grim": "^1",
     "interval-skip-list": "^2.0.0",
     "pathwatcher": "^4.0.1",
-    "q": "^1.1.2",
+    "q": "~1.0.1",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.1.1",
     "underscore-plus": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fs-plus": "^2.0.0",
     "grim": "^1",
     "interval-skip-list": "^2.0.0",
-    "pathwatcher": "^3.0.0",
+    "pathwatcher": "^4.0.1",
     "q": "^1.1.2",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1234,8 +1234,6 @@ class TextBuffer
   #
   # * `flushCache` (optional) {Boolean} flush option to pass through to
   #                {File::read} (default: false).
-  # * `callback`   (optional) {Function} to call after the cached contents have
-  #                been updated.
   updateCachedDiskContents: (flushCache=false) ->
     Q(@file?.read(flushCache) ? "").then (contents) =>
       @cachedDiskContents = contents


### PR DESCRIPTION
* Introduce a new parameter file to TextBuffer to allow injecting custom implementation of the file (e.g. a remote `File`)
* Remove the normal flow dependency on the `getDigest` being a synchronous function and introduce the `getDigestSync` for the (de)serialization usage

Dependency: https://github.com/atom/node-pathwatcher/pull/56 - that's the package.json reference