### PR TITLE
Adds "install": "grunt" script and moves grunt to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {
+    "install": "grunt",
     "prepublish": "grunt clean lint coffee shell:update-atomdoc atomdoc",
     "test": "grunt test"
   },
@@ -23,17 +24,17 @@
   "devDependencies": {
     "coffee-script": "~1.7.0",
     "jasmine-focused": "1.x",
-    "grunt-contrib-coffee": "~0.9.0",
-    "grunt-cli": "~0.1.8",
-    "grunt": "~0.4.1",
-    "grunt-shell": "~0.2.2",
-    "grunt-coffeelint": "0.0.6",
     "rimraf": "~2.2.2",
     "coffee-cache": "~0.2.0",
-    "temp": "~0.6.0",
-    "grunt-atomdoc": "^1.0"
+    "temp": "~0.6.0"
   },
   "dependencies": {
+    "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.8",
+    "grunt-coffeelint": "0.0.6",
+    "grunt-contrib-coffee": "~0.9.0",
+    "grunt-shell": "~0.2.2",
+    "grunt-atomdoc": "^1.0",
     "delegato": "^1.0.0",
     "atom-diff": "^2",
     "emissary": "^1.0.0",


### PR DESCRIPTION
Necessary because package.json lists "main" as a script which doesn't exist until text-buffer is built!