### PR TITLE
add did-delete event:

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1049,6 +1049,21 @@ describe "TextBuffer", ->
         expect(bufferToDelete.getPath()).toBe filePath
         expect(bufferToDelete.isModified()).toBeFalsy()
 
+
+    describe "when the file is deleted", ->
+      events = []
+      beforeEach ->
+        bufferToDelete.onDidDelete -> events.push true
+        deleteHandler = jasmine.createSpy('deleteHandler')
+        bufferToDelete.onDidDelete deleteHandler
+        removeSync(filePath)
+        waitsFor "file to be deleted", ->
+          deleteHandler.callCount > 0
+      
+      it "expects onDidDelete to have been called ", ->
+        expect(events).toEqual [true]
+
+
     it "resumes watching of the file when it is re-saved", ->
       bufferToDelete.save()
       expect(existsSync(bufferToDelete.getPath())).toBeTruthy()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -212,6 +212,16 @@ class TextBuffer
   onDidSave: (callback) ->
     @emitter.on 'did-save', callback
 
+
+  # Public: Invoke the given callback after the file backing the buffer is
+  # deleted.
+  #
+  # * `callback` {Function} to be called after the buffer is deleted.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidDelete: (callback) ->
+    @emitter.on 'did-delete', callback
+
   # Public: Invoke the given callback before the buffer is reloaded from the
   # contents of its file on disk.
   #
@@ -1289,6 +1299,7 @@ class TextBuffer
         @reload()
 
     @fileSubscriptions.add @file.onDidDelete =>
+      @emitter.emit 'did-delete'
       modified = @getText() != @cachedDiskContents
       @wasModifiedBeforeRemove = modified
       if modified


### PR DESCRIPTION
Adds did-delete event and dispatcher as well as a simple unit test.

Currently, plugins must rely on the file's did-delete event, but the underlying file can change or itself be deleted which makes the existing implementation cumbersome.