### PR TITLE
Supply `getRange` to `scanInRange` iterator

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1710,7 +1710,7 @@ describe "TextBuffer", ->
     describe "when given a regex with a ignore case flag", ->
       it "does a case-insensitive search", ->
         matches = []
-        buffer.scanInRange /cuRRent/i, [[0,0], [12,0]], ({match, range}) ->
+        buffer.scanInRange /cuRRent/i, [[0,0], [12,0]], ({match}) ->
           matches.push(match)
         expect(matches.length).toBe 1
 
@@ -1718,9 +1718,9 @@ describe "TextBuffer", ->
       it "calls the iterator with the first match for the given regex in the given range", ->
         matches = []
         ranges = []
-        buffer.scanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, range}) ->
+        buffer.scanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, getRange}) ->
           matches.push(match)
-          ranges.push(range)
+          ranges.push(getRange())
 
         expect(matches.length).toBe 1
         expect(ranges.length).toBe 1
@@ -1733,9 +1733,9 @@ describe "TextBuffer", ->
       it "calls the iterator with each match for the given regex in the given range", ->
         matches = []
         ranges = []
-        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, range}) ->
+        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, getRange}) ->
           matches.push(match)
-          ranges.push(range)
+          ranges.push(getRange())
 
         expect(matches.length).toBe 3
         expect(ranges.length).toBe 3
@@ -1757,9 +1757,9 @@ describe "TextBuffer", ->
         it "calls the iterator with the truncated match", ->
           matches = []
           ranges = []
-          buffer.scanInRange /cu(r*)/g, [[4,0], [6,9]], ({match, range}) ->
+          buffer.scanInRange /cu(r*)/g, [[4,0], [6,9]], ({match, getRange}) ->
             matches.push(match)
-            ranges.push(range)
+            ranges.push(getRange())
 
           expect(matches.length).toBe 2
           expect(ranges.length).toBe 2
@@ -1776,9 +1776,9 @@ describe "TextBuffer", ->
         it "calls the iterator with the truncated match", ->
           matches = []
           ranges = []
-          buffer.scanInRange /cu(r*)e/g, [[4,0], [6,9]], ({match, range}) ->
+          buffer.scanInRange /cu(r*)e/g, [[4,0], [6,9]], ({match, getRange}) ->
             matches.push(match)
-            ranges.push(range)
+            ranges.push(getRange())
 
           expect(matches.length).toBe 1
           expect(ranges.length).toBe 1
@@ -1790,8 +1790,8 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'replace' control function with a replacement string", ->
       it "replaces each occurrence of the regex match with the string", ->
         ranges = []
-        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, replace}) ->
-          ranges.push(range)
+        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, replace}) ->
+          ranges.push(getRange())
           replace("foo")
 
         expect(ranges[0]).toEqual [[5,6], [5,13]]
@@ -1811,8 +1811,8 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'stop' control function", ->
       it "stops the traversal", ->
         ranges = []
-        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, stop}) ->
-          ranges.push(range)
+        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, stop}) ->
+          ranges.push(getRange())
           stop() if ranges.length == 2
 
         expect(ranges.length).toBe 2
@@ -1829,9 +1829,9 @@ describe "TextBuffer", ->
       it "calls the iterator with the last match for the given regex in the given range", ->
         matches = []
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, range}) ->
+        buffer.backwardsScanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, getRange}) ->
           matches.push(match)
-          ranges.push(range)
+          ranges.push(getRange())
 
         expect(matches.length).toBe 1
         expect(ranges.length).toBe 1
@@ -1844,9 +1844,9 @@ describe "TextBuffer", ->
       it "calls the iterator with each match for the given regex in the given range, starting with the last match", ->
         matches = []
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, range}) ->
+        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, getRange}) ->
           matches.push(match)
-          ranges.push(range)
+          ranges.push(getRange())
 
         expect(matches.length).toBe 3
         expect(ranges.length).toBe 3
@@ -1866,9 +1866,9 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'replace' control function with a replacement string", ->
       it "replaces each occurrence of the regex match with the string", ->
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, replace}) ->
-          ranges.push(range)
-          replace("foo") unless range.start.isEqual([6,6])
+        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, replace}) ->
+          ranges.push(getRange())
+          replace("foo") unless getRange().start.isEqual([6,6])
 
         expect(ranges[0]).toEqual [[6,34], [6,41]]
         expect(ranges[1]).toEqual [[6,6], [6,13]]
@@ -1880,8 +1880,8 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'stop' control function", ->
       it "stops the traversal", ->
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, stop}) ->
-          ranges.push(range)
+        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, stop}) ->
+          ranges.push(getRange())
           stop() if ranges.length == 2
 
         expect(ranges.length).toBe 2

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1710,7 +1710,7 @@ describe "TextBuffer", ->
     describe "when given a regex with a ignore case flag", ->
       it "does a case-insensitive search", ->
         matches = []
-        buffer.scanInRange /cuRRent/i, [[0,0], [12,0]], ({match}) ->
+        buffer.scanInRange /cuRRent/i, [[0,0], [12,0]], ({match, range}) ->
           matches.push(match)
         expect(matches.length).toBe 1
 
@@ -1718,9 +1718,9 @@ describe "TextBuffer", ->
       it "calls the iterator with the first match for the given regex in the given range", ->
         matches = []
         ranges = []
-        buffer.scanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, getRange}) ->
+        buffer.scanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, range}) ->
           matches.push(match)
-          ranges.push(getRange())
+          ranges.push(range)
 
         expect(matches.length).toBe 1
         expect(ranges.length).toBe 1
@@ -1733,9 +1733,9 @@ describe "TextBuffer", ->
       it "calls the iterator with each match for the given regex in the given range", ->
         matches = []
         ranges = []
-        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, getRange}) ->
+        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, range}) ->
           matches.push(match)
-          ranges.push(getRange())
+          ranges.push(range)
 
         expect(matches.length).toBe 3
         expect(ranges.length).toBe 3
@@ -1757,9 +1757,9 @@ describe "TextBuffer", ->
         it "calls the iterator with the truncated match", ->
           matches = []
           ranges = []
-          buffer.scanInRange /cu(r*)/g, [[4,0], [6,9]], ({match, getRange}) ->
+          buffer.scanInRange /cu(r*)/g, [[4,0], [6,9]], ({match, range}) ->
             matches.push(match)
-            ranges.push(getRange())
+            ranges.push(range)
 
           expect(matches.length).toBe 2
           expect(ranges.length).toBe 2
@@ -1776,9 +1776,9 @@ describe "TextBuffer", ->
         it "calls the iterator with the truncated match", ->
           matches = []
           ranges = []
-          buffer.scanInRange /cu(r*)e/g, [[4,0], [6,9]], ({match, getRange}) ->
+          buffer.scanInRange /cu(r*)e/g, [[4,0], [6,9]], ({match, range}) ->
             matches.push(match)
-            ranges.push(getRange())
+            ranges.push(range)
 
           expect(matches.length).toBe 1
           expect(ranges.length).toBe 1
@@ -1790,8 +1790,8 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'replace' control function with a replacement string", ->
       it "replaces each occurrence of the regex match with the string", ->
         ranges = []
-        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, replace}) ->
-          ranges.push(getRange())
+        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, replace}) ->
+          ranges.push(range)
           replace("foo")
 
         expect(ranges[0]).toEqual [[5,6], [5,13]]
@@ -1811,8 +1811,8 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'stop' control function", ->
       it "stops the traversal", ->
         ranges = []
-        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, stop}) ->
-          ranges.push(getRange())
+        buffer.scanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, stop}) ->
+          ranges.push(range)
           stop() if ranges.length == 2
 
         expect(ranges.length).toBe 2
@@ -1829,9 +1829,9 @@ describe "TextBuffer", ->
       it "calls the iterator with the last match for the given regex in the given range", ->
         matches = []
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, getRange}) ->
+        buffer.backwardsScanInRange /cu(rr)ent/, [[4,0], [6,44]], ({match, range}) ->
           matches.push(match)
-          ranges.push(getRange())
+          ranges.push(range)
 
         expect(matches.length).toBe 1
         expect(ranges.length).toBe 1
@@ -1844,9 +1844,9 @@ describe "TextBuffer", ->
       it "calls the iterator with each match for the given regex in the given range, starting with the last match", ->
         matches = []
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, getRange}) ->
+        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({match, range}) ->
           matches.push(match)
-          ranges.push(getRange())
+          ranges.push(range)
 
         expect(matches.length).toBe 3
         expect(ranges.length).toBe 3
@@ -1866,9 +1866,9 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'replace' control function with a replacement string", ->
       it "replaces each occurrence of the regex match with the string", ->
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, replace}) ->
-          ranges.push(getRange())
-          replace("foo") unless getRange().start.isEqual([6,6])
+        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, replace}) ->
+          ranges.push(range)
+          replace("foo") unless range.start.isEqual([6,6])
 
         expect(ranges[0]).toEqual [[6,34], [6,41]]
         expect(ranges[1]).toEqual [[6,6], [6,13]]
@@ -1880,8 +1880,8 @@ describe "TextBuffer", ->
     describe "when the iterator calls the 'stop' control function", ->
       it "stops the traversal", ->
         ranges = []
-        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({getRange, stop}) ->
-          ranges.push(getRange())
+        buffer.backwardsScanInRange /cu(rr)ent/g, [[4,0], [6,59]], ({range, stop}) ->
+          ranges.push(range)
           stop() if ranges.length == 2
 
         expect(ranges.length).toBe 2

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -976,13 +976,18 @@ class TextBuffer
       matchStartIndex = match.index
       matchEndIndex = matchStartIndex + matchLength
 
-      startPosition = @positionForCharacterIndex(matchStartIndex + lengthDelta)
-      endPosition = @positionForCharacterIndex(matchEndIndex + lengthDelta)
-      range = new Range(startPosition, endPosition)
+      getRange = =>
+        startPosition = @positionForCharacterIndex(matchStartIndex + lengthDelta)
+        endPosition = @positionForCharacterIndex(matchEndIndex + lengthDelta)
+
+        new Range(startPosition, endPosition)
+
+      # FIXME: Remove this as soon as all clients use `getRange` in their iterators.
+      range = getRange()
       keepLooping = true
       replacementText = null
       matchText = match[0]
-      iterator({ match, matchText, range, stop, replace })
+      iterator({ match, matchText, range, stop, replace, getRange })
 
       if replacementText?
         @setTextInRange(range, replacementText)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -40,13 +40,15 @@ class SearchResultCallback
     @stopped is false
 
   getRange: =>
+    return @computedRange if @computedRange?
+
     matchStartIndex = @match.index
     matchEndIndex = matchStartIndex + @matchText.length
 
     startPosition = @buffer.positionForCharacterIndex(matchStartIndex + @lengthDelta)
     endPosition = @buffer.positionForCharacterIndex(matchEndIndex + @lengthDelta)
 
-    new Range(startPosition, endPosition)
+    @computedRange = new Range(startPosition, endPosition)
 
 class TransactionAbortedError extends Error
   constructor: -> super

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -39,7 +39,7 @@ class SearchResultCallback
   keepLooping: ->
     @stopped is false
 
-  getRange: ->
+  getRange: =>
     matchStartIndex = @match.index
     matchEndIndex = matchStartIndex + @matchText.length
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -13,7 +13,7 @@ MarkerStore = require './marker-store'
 Patch = require './patch'
 {spliceArray, newlineRegex} = require './helpers'
 
-class SearchResultCallback
+class SearchResultIteratee
   Object.defineProperty @::, "range",
     get: ->
       return @computedRange if @computedRange?
@@ -1003,11 +1003,11 @@ class TextBuffer
 
     matches.reverse() if reverse
     for match in matches
-      callback = new SearchResultCallback(this, match, lengthDelta)
-      iterator(callback)
-      lengthDelta += callback.getReplacementDelta() unless reverse
+      resultIteratee = new SearchResultIteratee(this, match, lengthDelta)
+      iterator(resultIteratee)
+      lengthDelta += resultIteratee.getReplacementDelta() unless reverse
 
-      break unless global and callback.keepLooping()
+      break unless global and resultIteratee.keepLooping()
     return
 
   # Public: Scan regular expression matches in a given range in reverse order,

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -21,17 +21,14 @@ class SearchResultCallback
     @replacementText = null
     @matchText = @match[0]
 
-  hasReplacedText: ->
-    @replacementText?
-
-  getReplacementText: ->
-    @replacementText
-
   getReplacementDelta: ->
-    @getReplacementText().length - @matchText.length
+    return 0 unless @replacementText?
+
+    @replacementText.length - @matchText.length
 
   replace: (text) =>
     @replacementText = text
+    @buffer.setTextInRange(@getRange(), @replacementText)
 
   stop: =>
     @stopped = true
@@ -1006,10 +1003,7 @@ class TextBuffer
     for match in matches
       callback = new SearchResultCallback(this, match, lengthDelta)
       iterator(callback)
-
-      if callback.hasReplacedText()
-        @setTextInRange(callback.getRange(), callback.getReplacementText())
-        lengthDelta += callback.getReplacementDelta() unless reverse
+      lengthDelta += callback.getReplacementDelta() unless reverse
 
       break unless global and callback.keepLooping()
     return

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -13,7 +13,7 @@ MarkerStore = require './marker-store'
 Patch = require './patch'
 {spliceArray, newlineRegex} = require './helpers'
 
-class SearchResultIteratee
+class SearchCallbackArgument
   Object.defineProperty @::, "range",
     get: ->
       return @computedRange if @computedRange?
@@ -1003,11 +1003,11 @@ class TextBuffer
 
     matches.reverse() if reverse
     for match in matches
-      resultIteratee = new SearchResultIteratee(this, match, lengthDelta)
-      iterator(resultIteratee)
-      lengthDelta += resultIteratee.getReplacementDelta() unless reverse
+      callbackArgument = new SearchCallbackArgument(this, match, lengthDelta)
+      iterator(callbackArgument)
+      lengthDelta += callbackArgument.getReplacementDelta() unless reverse
 
-      break unless global and resultIteratee.keepLooping()
+      break unless global and callbackArgument.keepLooping()
     return
 
   # Public: Scan regular expression matches in a given range in reverse order,


### PR DESCRIPTION
While scanning a large file, we may not want to compute the position for every result. This is especially important for searches where there’s an elevated amount of matches and we’re interested only in a subset of them.

This commit introduces a `getRange` parameter in the `iterator` function, which is suited to be a drop-in replacement for `range`. The logic is the same, but passing a function, or a getter if you will, enables us to perform all the position math (i.e. `positionForCharacterIndex` is rather expensive) lazily. :racehorse:

This is still “slow”, however, because we cannot delete the `range` parameter without first changing all the scan methods' clients to use `getRange` instead. Thus, we need to work incrementally by shipping both versions (eagerly and lazily computed `range`) and remove the eagerly computed one as soon as we complete the migration.

After that, we will benefit from a significant performance boost thereby solving bracket-matcher slowness when matching parentheses in a reasonably long file.

### Core Repos To Be Updated

* [ ] [atom-autocomplete](https://github.com/atom/autocomplete/tree/master/lib/autocomplete-view.coffee) (we may probably skip it, as we use autocomplete-plus now)
* [ ] [find-and-replace](https://github.com/atom/find-and-replace)
* [ ] [bracket-matcher](https://github.com/atom/bracket-matcher)
* [ ] [atom](https://github.com/atom/atom)


/cc: @nathansobo @maxbrunsfeld @atom/feedback 