### PR TITLE
Restore markers correctly after redo

### DIFF
--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -824,6 +824,32 @@ describe "Marker", ->
         buffer.undo()
         expect(marker.getRange()).toEqual [[0, 3], [0, 3]]
 
+    describe "when a marker is updated before a redo", ->
+      it "restores the marker to its state after the redone change", ->
+        marker = buffer.markRange([[0, 3], [0, 3]])
+
+        # Update marker *before* an undo
+        buffer.insert([0, 3], "...")
+        expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
+
+        buffer.undo()
+        expect(marker.getRange()).toEqual [[0, 3], [0, 3]]
+
+        marker.setRange([[0, 10], [0, 10]])
+        buffer.redo()
+        expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
+
+        # Update marker *after* an undo
+        buffer.insert([0, 3], "...")
+        expect(marker.getRange()).toEqual [[0, 3], [0, 9]]
+
+        marker.setRange([[0, 12], [0, 12]])
+        buffer.undo()
+        expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
+
+        buffer.redo()
+        expect(marker.getRange()).toEqual [[0, 3], [0, 9]]
+
   describe "destruction", ->
     it "removes the marker from the buffer, marks it destroyed and invalid, and notifies ::onDidDestroy observers", ->
       marker = buffer.markRange([[0, 3], [0, 6]])

--- a/src/marker-store.coffee
+++ b/src/marker-store.coffee
@@ -128,19 +128,15 @@ class MarkerStore
         else
           marker.emitChangeEvent(marker.getRange(), true, false)
 
-  emitChangeEvents: ->
-    ranges = @index.dump()
-    for id in Object.keys(@markersById)
-      if marker = @markersById[id]
-        marker.emitChangeEvent(ranges[id], true, false)
-
-  createSnapshot: (filterPersistent) ->
+  createSnapshot: (filterPersistent, emitChangeEvents) ->
     result = {}
     ranges = @index.dump()
     for id in Object.keys(@markersById)
-      marker = @markersById[id]
-      unless filterPersistent and not marker.persistent
-        result[id] = marker.getSnapshot(ranges[id], false)
+      if marker = @markersById[id]
+        if marker.persistent or not filterPersistent
+          result[id] = marker.getSnapshot(ranges[id], false)
+        if emitChangeEvents
+          marker.emitChangeEvent(ranges[id], true, false)
     result
 
   serialize: ->


### PR DESCRIPTION
Fixes atom/atom#6915

#### Problem

Currently, on `redo`, we restore markers to the state they were in *before the corresponding undo operation*. This is not quite right; markers that have existed since the redone change should be restored to the state they were in *after the redone change initially occurred*.

#### Solution

Previously, we created marker snapshots in 3 situations: before transactions, before undo, and before redo. To fix this bug, we need to also create a marker snapshot immediately *after* every transaction. So now I do that as part of emitting marker change events, and store the marker snapshot as a new property on the `TextBuffer`: `lastMarkerSnapshot`.

/cc @nathansobo could you review this?