### PR TITLE
Marker Index Low Hanging Fruits

### DIFF
--- a/src/marker-index.coffee
+++ b/src/marker-index.coffee
@@ -381,12 +381,16 @@ class MarkerIndex
       Range(start, @getEnd(id))
 
   getStart: (id) ->
-    if entry = @rangeCache[id]
-      entry.start ?= @rootNode.getStart(id)
+    return unless @rootNode.ids.has(id)
+
+    entry = @rangeCache[id] ?= templateRange()
+    entry.start ?= @rootNode.getStart(id)
 
   getEnd: (id) ->
-    if entry = @rangeCache[id]
-      entry.end ?= @rootNode.getEnd(id)
+    return unless @rootNode.ids.has(id)
+
+    entry = @rangeCache[id] ?= templateRange()
+    entry.end ?= @rootNode.getEnd(id)
 
   findContaining: (start, end) ->
     containing = new Set
@@ -439,6 +443,7 @@ class MarkerIndex
 
   dump: ->
     unless @rangeCacheFresh
+      @rootNode.ids.forEach (id) => @rangeCache[id] ?= templateRange()
       @rootNode.dump(Point.ZERO, @rangeCache)
       @rangeCacheFresh = true
     @rangeCache
@@ -449,7 +454,6 @@ class MarkerIndex
 
   clearRangeCache: ->
     @rangeCache = {}
-    @rootNode.ids.forEach (id) => @rangeCache[id] = templateRange()
     @rangeCacheFresh = false
 
   condenseIfNeeded: ->

--- a/src/marker-index.coffee
+++ b/src/marker-index.coffee
@@ -462,6 +462,4 @@ assertValidId = (id) ->
     throw new TypeError("Marker ID must be a string")
 
 templateRange = ->
-  range = new Range(Point.ZERO, Point.ZERO)
-  range.start = range.end = null
-  range
+  Object.create(Range.prototype)

--- a/src/set-helpers.coffee
+++ b/src/set-helpers.coffee
@@ -6,7 +6,10 @@ setEqual = (a, b) ->
   true
 
 subtractSet = (set, valuesToRemove) ->
-  valuesToRemove.forEach (value) -> set.delete(value)
+  if set.size > valuesToRemove.size
+    valuesToRemove.forEach (value) -> set.delete(value)
+  else
+    set.forEach (value) -> set.delete(value) if valuesToRemove.has(value)
 
 addSet = (set, valuesToAdd) ->
   valuesToAdd.forEach (value) -> set.add(value)


### PR DESCRIPTION
These straightforward, yet effective changes improve performance by ~2s when inserting text on 1000 different cursors (~ 25% improvement). We cannot claim we're fast yet, but we're getting there :raised_hands: 

| Before | After  |
| --------- | -------|
| ![screen shot 2015-06-02 at 21 25 39](https://cloud.githubusercontent.com/assets/482957/7944926/f4f212f8-096d-11e5-917d-834cf4cea43c.png) | ![screen shot 2015-06-02 at 21 25 33](https://cloud.githubusercontent.com/assets/482957/7944927/f510fe34-096d-11e5-834b-a6c01a164d0f.png)

One more improvement I could think of right now would be to defer [marker invalidation](https://github.com/atom/text-buffer/blob/master/src/marker-store.coffee#L100-L119) and perform it at the end of a transaction: this should give another significant boost to `MarkerStore`, which after that should just take ~250ms instead of 1s (i.e. when typing a letter for 1000 cursors). This appears to be quite disruptive, though, and may require some additional thinking, therefore I decided to leave it for a later moment.

An additional pair of :eyes: is most welcome, therefore please do not hesitate to leave your feedback. Thanks! :bow: 

/cc: @maxbrunsfeld @nathansobo 