### PR TITLE
Preserve correct marker snapshots in undo/redo stack

### DIFF
--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -841,31 +841,39 @@ describe "Marker", ->
         buffer.undo()
         expect(marker.getRange()).toEqual [[0, 3], [0, 3]]
 
-    describe "when a marker is updated before a redo", ->
-      it "restores the marker to its state after the redone change", ->
-        marker = buffer.markRange([[0, 3], [0, 3]])
+    describe "when a marker is updated before undoing or redoing", ->
+      it "restores the marker to its state before/after the undone/redone change", ->
+        marker = buffer.markRange([[0, 5], [0, 5]])
 
-        # Update marker *before* an undo
-        buffer.insert([0, 3], "...")
-        expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
+        buffer.insert([0, 5], "...")
+        expect(marker.getRange()).toEqual [[0, 5], [0, 8]]
+
+        buffer.insert([0, 8], "???")
+        expect(marker.getRange()).toEqual [[0, 5], [0, 11]]
+
+        marker.setRange([[0, 0], [0, 1]])
+        marker.setRange([[0, 0], [0, 2]])
 
         buffer.undo()
-        expect(marker.getRange()).toEqual [[0, 3], [0, 3]]
+        expect(marker.getRange()).toEqual [[0, 5], [0, 8]]
 
-        marker.setRange([[0, 10], [0, 10]])
-        buffer.redo()
-        expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
+        marker.setRange([[0, 0], [0, 1]])
+        marker.setRange([[0, 0], [0, 2]])
 
-        # Update marker *after* an undo
-        buffer.insert([0, 3], "...")
-        expect(marker.getRange()).toEqual [[0, 3], [0, 9]]
-
-        marker.setRange([[0, 12], [0, 12]])
         buffer.undo()
-        expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
+        expect(marker.getRange()).toEqual [[0, 5], [0, 5]]
+
+        marker.setRange([[0, 0], [0, 1]])
+        marker.setRange([[0, 0], [0, 2]])
 
         buffer.redo()
-        expect(marker.getRange()).toEqual [[0, 3], [0, 9]]
+        expect(marker.getRange()).toEqual [[0, 5], [0, 8]]
+
+        marker.setRange([[0, 0], [0, 1]])
+        marker.setRange([[0, 0], [0, 2]])
+
+        buffer.redo()
+        expect(marker.getRange()).toEqual [[0, 5], [0, 11]]
 
   describe "destruction", ->
     it "removes the marker from the buffer, marks it destroyed and invalid, and notifies ::onDidDestroy observers", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -586,17 +586,24 @@ describe "TextBuffer", ->
       expect(buffer.getText()).toBe("")
 
     it "preserves checkpoints across undo and redo", ->
-      buffer.append("hello\n")
-      checkpoint = buffer.createCheckpoint()
+      buffer.append("a")
+      buffer.append("b")
+      checkpoint1 = buffer.createCheckpoint()
+      buffer.append("c")
+      checkpoint2 = buffer.createCheckpoint()
+
       buffer.undo()
-      expect(buffer.getText()).toBe("")
+      expect(buffer.getText()).toBe("ab")
 
       buffer.redo()
-      expect(buffer.getText()).toBe("hello\n")
+      expect(buffer.getText()).toBe("abc")
 
-      buffer.append("world")
-      buffer.revertToCheckpoint(checkpoint)
-      expect(buffer.getText()).toBe("hello\n")
+      buffer.append("d")
+
+      expect(buffer.revertToCheckpoint(checkpoint2)).toBe true
+      expect(buffer.getText()).toBe("abc")
+      expect(buffer.revertToCheckpoint(checkpoint1)).toBe true
+      expect(buffer.getText()).toBe("ab")
 
     it "handles checkpoints created when there have been no changes", ->
       checkpoint = buffer.createCheckpoint()

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -60,9 +60,9 @@ class History
   popUndoStack: (currentSnapshot) ->
     if (checkpointIndex = @getBoundaryCheckpointIndex(@undoStack))?
       pop = @popChanges(@undoStack, @redoStack, checkpointIndex)
-      _.defaults(pop.snapshotBefore, currentSnapshot)
+      _.defaults(pop.snapshotAbove, currentSnapshot)
       {
-        snapshot: pop.snapshotAfter
+        snapshot: pop.snapshotBelow
         changes: (@delegate.invertChange(change) for change in pop.changes)
       }
     else
@@ -73,9 +73,9 @@ class History
       checkpointIndex-- while @redoStack[checkpointIndex - 1] instanceof Checkpoint
       checkpointIndex++ if @redoStack[checkpointIndex - 1]?
       pop = @popChanges(@redoStack, @undoStack, checkpointIndex, true)
-      _.defaults(pop.snapshotBefore, currentSnapshot)
+      _.defaults(pop.snapshotAbove, currentSnapshot)
       {
-        snapshot: pop.snapshotAfter
+        snapshot: pop.snapshotBelow
         changes: pop.changes
       }
     else
@@ -85,7 +85,7 @@ class History
     if (checkpointIndex = @getCheckpointIndex(checkpointId))?
       pop = @popChanges(@undoStack, null, checkpointIndex)
       {
-        snapshot: pop.snapshotAfter
+        snapshot: pop.snapshotBelow
         changes: (@delegate.invertChange(change) for change in pop.changes)
       }
     else
@@ -130,16 +130,16 @@ class History
 
   popChanges: (fromStack, toStack, checkpointIndex, lookBack) ->
     changes = []
-    snapshotBefore = null
-    snapshotAfter = fromStack[checkpointIndex].snapshot
+    snapshotAbove = null
+    snapshotBelow = fromStack[checkpointIndex].snapshot
     splicedEntries = fromStack.splice(checkpointIndex)
     for entry in splicedEntries by -1
       toStack?.push(entry)
       if entry instanceof Checkpoint
-        snapshotBefore = entry.snapshot if changes.length is 0
+        snapshotAbove = entry.snapshot if changes.length is 0
       else
         changes.push(entry)
-    {changes, snapshotBefore, snapshotAfter}
+    {changes, snapshotAbove, snapshotBelow}
 
   serializeStack: (stack) ->
     for entry in stack

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -26,13 +26,8 @@ class History
   groupChangesSinceCheckpoint: (checkpointId) ->
     checkpointIndex = @getCheckpointIndex(checkpointId)
     return false unless checkpointIndex?
-    hasSeenChanges = false
-    for entry, i in @undoStack by -1
-      break if i is checkpointIndex
-      if @undoStack[i] instanceof Checkpoint
-        @undoStack.splice(i, 1) if hasSeenChanges
-      else
-        hasSeenChanges = true
+    for i in [(@undoStack.length - 2)...checkpointIndex] by -1
+      @undoStack.splice(i, 1) if @undoStack[i] instanceof Checkpoint
     true
 
   applyCheckpointGroupingInterval: (checkpointId, now, groupingInterval) ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -884,8 +884,10 @@ class TextBuffer
 
     @history.groupChangesSinceCheckpoint(checkpointBefore)
     checkpointAfter = @history.createCheckpoint(@markerStore.createSnapshot(false, true))
-    @history.applyCheckpointGroupingInterval(checkpointBefore, groupingInterval)
-    @history.applyCheckpointGroupingInterval(checkpointAfter, groupingInterval)
+
+    now = Date.now()
+    @history.setCheckpointGroupingInterval(checkpointAfter, now, groupingInterval)
+    @history.applyCheckpointGroupingInterval(checkpointBefore, now, groupingInterval)
     result
 
   abortTransaction: ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -882,8 +882,8 @@ class TextBuffer
     finally
       @transactCallDepth--
 
-    @history.groupChangesSinceCheckpoint(checkpointBefore)
     checkpointAfter = @history.createCheckpoint(@markerStore.createSnapshot(false, true))
+    @history.groupChangesSinceCheckpoint(checkpointBefore)
 
     now = Date.now()
     @history.setCheckpointGroupingInterval(checkpointAfter, now, groupingInterval)


### PR DESCRIPTION
Now, whenever we perform a transaction, we push two `Checkpoints` to the undo history: one before and one after.

/cc @nathansobo