### PR TITLE
Speed up marker snapshotting by allowing markers to opt out of it

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -51,4 +51,4 @@ currentSpecFailed = ->
     .getItems()
     .some (item) -> not item.passed()
 
-module.exports = {toEqualSet, currentSpecFailed}
+module.exports = {toEqualSet, currentSpecFailed, formatSet}

--- a/src/marker-store.coffee
+++ b/src/marker-store.coffee
@@ -131,13 +131,15 @@ class MarkerStore
     @delegate.markersUpdated()
     return
 
-  createSnapshot: (filterPersistent, emitChangeEvents) ->
+  createSnapshot: (forSerialization=false, emitChangeEvents=false) ->
     result = {}
     ranges = @index.dump()
     for id in Object.keys(@markersById)
       if marker = @markersById[id]
-        if marker.persistent or not filterPersistent
-          result[id] = marker.getSnapshot(ranges[id], false)
+        if forSerialization
+          result[id] = marker.getSnapshot(ranges[id], false) if marker.persistent
+        else
+          result[id] = marker.getSnapshot(ranges[id], false) if marker.maintainHistory
         if emitChangeEvents
           marker.emitChangeEvent(ranges[id], true, false)
     @delegate.markersUpdated() if emitChangeEvents

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -359,7 +359,7 @@ class Marker
     updated
 
   getSnapshot: (range) ->
-    Object.freeze({range, @properties, @reversed, @tailed, @valid, @invalidate})
+    Object.freeze({range, @properties, @reversed, @tailed, @valid, @invalidate, @maintainHistory})
 
   toString: ->
     "[Marker #{@id}, #{@getRange()}]"
@@ -371,6 +371,8 @@ class Marker
   emitChangeEvent: (currentRange, textChanged, propertiesChanged) ->
     return unless @hasChangeObservers
     oldState = @previousEventState
+
+    currentRange ?= @getRange()
 
     return false unless propertiesChanged or
       oldState.valid isnt @valid or

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -5,7 +5,7 @@ Delegator = require 'delegato'
 Point = require './point'
 Range = require './range'
 
-OptionKeys = new Set(['reversed', 'tailed', 'invalidate', 'persistent'])
+OptionKeys = new Set(['reversed', 'tailed', 'invalidate', 'persistent', 'maintainHistory'])
 
 # Private: Represents a buffer annotation that remains logically stationary
 # even as the buffer changes. This is used to represent cursors, folds, snippet
@@ -44,13 +44,14 @@ class Marker
   @delegatesMethods 'containsPoint', 'containsRange', 'intersectsRow', toMethod: 'getRange'
 
   constructor: (@id, @store, range, params) ->
-    {@tailed, @reversed, @valid, @invalidate, @persistent, @properties} = params
+    {@tailed, @reversed, @valid, @invalidate, @persistent, @properties, @maintainHistory} = params
     @emitter = new Emitter
     @tailed ?= true
     @reversed ?= false
     @valid ?= true
     @invalidate ?= 'overlap'
     @persistent ?= true
+    @maintainHistory ?= true
     @properties ?= {}
     @hasChangeObservers = false
     @rangeWhenDestroyed = null
@@ -240,6 +241,7 @@ class Marker
     @invalidate is other.invalidate and
       @tailed is other.tailed and
       @persistent is other.persistent and
+      @maintainHistory is other.maintainHistory and
       @reversed is other.reversed and
       isEqual(@properties, other.properties) and
       @getRange().isEqual(other.getRange())

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -870,7 +870,7 @@ class TextBuffer
       fn = groupingInterval
       groupingInterval = 0
 
-    checkpointBefore = @createCheckpoint()
+    checkpointBefore = @history.createCheckpoint(@markerStore.createSnapshot(false))
 
     try
       @transactCallDepth++
@@ -882,7 +882,7 @@ class TextBuffer
     finally
       @transactCallDepth--
 
-    checkpointAfter = @history.createCheckpoint(@markerStore.createSnapshot(false, true))
+    checkpointAfter = @history.createCheckpoint(@markerStore.createSnapshot(true))
     @history.groupChangesSinceCheckpoint(checkpointBefore)
 
     now = Date.now()


### PR DESCRIPTION
This adds a new boolean option called `maintainHistory` to `TextBuffer::markRange` and `::markPosition`. If set to false, the marker will not be snapshotted in the undo/redo history. This alleviates a major performance problem in Atom when there is a large find-and-replace search.