### PR TITLE
Optimize buffer search

### DIFF
--- a/src/match-iterator.coffee
+++ b/src/match-iterator.coffee
@@ -1,0 +1,78 @@
+class Forwards
+  constructor: (@text, @regex, @startIndex, @endIndex) ->
+    @regex.lastIndex = @startIndex
+
+  next: ->
+    if match = @regex.exec(@text)
+      matchLength = match[0].length
+      matchStartIndex = match.index
+      matchEndIndex = matchStartIndex + matchLength
+      if matchEndIndex > @endIndex
+        @regex.lastIndex = 0
+        if matchStartIndex < @endIndex and submatch = @regex.exec(@text[matchStartIndex...@endIndex])
+          submatch.index = matchStartIndex
+          match = submatch
+        else
+          match = null
+        @regex.lastIndex = Infinity
+      else
+        matchEndIndex++ if matchLength is 0
+        @regex.lastIndex = matchEndIndex
+
+    if match
+      {value: match, done: false}
+    else
+      {value: null, done: true}
+
+class Backwards
+  constructor: (@text, @regex, @startIndex, endIndex, @chunkSize) ->
+    @bufferedMatches = []
+    @chunkStartIndex = @chunkEndIndex = endIndex
+    @lastMatchIndex = Infinity
+
+  scanNextChunk: ->
+    return false if @chunkStartIndex is @startIndex
+
+    # If results were found in the last chunk, then scan to the beginning
+    # of the previous result. Otherwise, continue to scan to the same position
+    # as before.
+    @chunkEndIndex = Math.min(@chunkEndIndex, @lastMatchIndex)
+    @chunkStartIndex = Math.max(@startIndex, @chunkStartIndex - @chunkSize)
+
+    firstResultIndex = null
+    @regex.lastIndex = @chunkStartIndex
+    while match = @regex.exec(@text)
+      matchLength = match[0].length
+      matchStartIndex = match.index
+      matchEndIndex = matchStartIndex + matchLength
+
+      # If the match occurs at the beginning of the chunk, expand the chunk
+      # in case the match could have started earlier.
+      break if matchStartIndex == @chunkStartIndex > @startIndex
+      break if matchStartIndex >= @chunkEndIndex
+
+      if matchEndIndex > @chunkEndIndex
+        @regex.lastIndex = 0
+        if submatch = @regex.exec(@text[matchStartIndex...@chunkEndIndex])
+          submatch.index = matchStartIndex
+          firstResultIndex ?= matchStartIndex
+          @bufferedMatches.push(submatch)
+        break
+      else
+        firstResultIndex ?= matchStartIndex
+        @bufferedMatches.push(match)
+        matchEndIndex++ if matchLength is 0
+        @regex.lastIndex = matchEndIndex
+
+    @lastMatchIndex = firstResultIndex if firstResultIndex
+    true
+
+  next: ->
+    while @bufferedMatches.length is 0
+      break unless @scanNextChunk()
+    if match = @bufferedMatches.pop()
+      {value: match, done: false}
+    else
+      {value: null, done: true}
+
+module.exports = {Forwards, Backwards}


### PR DESCRIPTION
* [x] Get existing tests passing against the optimized implementation.
* [x] Add random tests for `::scanInRange()` and `::backwardsScanInRange()`, since their implementation is a little more complex now.
* [x] Make sure that packages that uses these methods (e.g. `bracket-matcher`) work in all cases.

#### Problem

The `scanInRange()` method allows the caller to stop the scan by calling the `stop()` function from within the scan callback. Currently though, we scan the entire buffer range and collect the matches in an Array before calling the callback. This causes scan operations to be slow for large files, even if the caller is only looking for the first match. 

Here's a flame graph for moving the cursor to the end of the word in a 2.3MB file. There's a bunch of garbage collection pauses due to buffering the matches. The operation took **250ms**.

![screen shot 2015-06-08 at 2 31 43 pm](https://cloud.githubusercontent.com/assets/326587/8045880/8896ffe2-0deb-11e5-9031-512744988c5f.png)

#### Solution

We call the scan callback as soon as we find each match, so that if `stop()` is called, we can avoid any further calls to `RegExp.prototype.exec()`.

It's a little tricky for `backwardsScanInRange()`. Whereas before we simply scanned the entire range and then reversed the array of matches, we now need to break the range into chunks and scan each chunk. If no matches are found within a chunk, we need to expand the chunk backwards, in case matches straddle chunk boundaries.

Here's a flame graph for the same operation as above:

![screen shot 2015-06-08 at 2 32 29 pm](https://cloud.githubusercontent.com/assets/326587/8045993/51180452-0dec-11e5-8f5e-dd235ae43303.png)

It took **12ms**. You can now hold down `alt-right` in a big file without locking the UI.