### PR TITLE
Validate Points earlier when creating markers

### DIFF
--- a/spec/marker-index-spec.coffee
+++ b/spec/marker-index-spec.coffee
@@ -277,25 +277,6 @@ describe "MarkerIndex", ->
         markerIndex.splice(Point(0, 5), Point(0, 3), Point(1, 3))
         expect(markerIndex.getRange("a")).toEqual Range(Point(1, 3), Point(1, 4))
 
-  describe "validations", ->
-    it "throws an error if an invalid point is passed to ::insert", ->
-      expect -> markerIndex.insert("invalid", Point(0, NaN), Point(0, 4))
-        .toThrow "Invalid Point: (0, NaN)"
-      expect -> markerIndex.insert("invalid", Point(0, "a-string"), Point(0, 4))
-        .toThrow "Invalid Point: (0, a-string)"
-      expect -> markerIndex.insert("invalid", Point(0, 3), Point(0, {}))
-        .toThrow "Invalid Point: (0, [object Object])"
-
-    it "throws an error if an invalid point is passed to ::splice", ->
-      markerIndex.insert("a", Point(0, 3), Point(0, 5))
-
-      expect -> markerIndex.splice(Point(0, NaN), Point(0, 2), Point(0, 3))
-        .toThrow "Invalid Point: (0, NaN)"
-      expect -> markerIndex.splice(Point(0, 1), Point(0, NaN), Point(0, 3))
-        .toThrow "Invalid Point: (0, NaN)"
-      expect -> markerIndex.splice(Point(0, 1), Point(0, 2), Point(0, NaN))
-        .toThrow "Invalid Point: (0, NaN)"
-
   describe "::dump()", ->
     it "returns an object containing each marker's range", ->
       markerIndex.insert("a", Point(0, 2), Point(0, 5))

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -63,6 +63,17 @@ describe "Marker", ->
         expect(marker1.getRange()).toEqual [[0, 3], [0, 3]]
         expect(marker2.getRange()).toEqual [[0, 5], [0, 5]]
 
+      it "throws an error if an invalid point is given", ->
+        marker1 = buffer.markRange([[0, 1], [0, 2]])
+
+        expect -> buffer.markRange([[0, NaN], [0, 2]])
+          .toThrow "Invalid Point: (0, NaN)"
+        expect -> buffer.markRange([[0, 1], [0, NaN]])
+          .toThrow "Invalid Point: (0, NaN)"
+
+        expect(buffer.findMarkers({})).toEqual [marker1]
+        expect(buffer.getMarkers()).toEqual [marker1]
+
     describe "TextBuffer::markPosition(position, properties)", ->
       it "creates a tail-less marker at the given position", ->
         marker = buffer.markPosition([0, 6])
@@ -80,6 +91,15 @@ describe "Marker", ->
       it "allows custom state to be assigned", ->
         marker = buffer.markPosition([0, 3], foo: 1, bar: 2)
         expect(marker.getProperties()).toEqual {foo: 1, bar: 2}
+
+      it "throws an error if an invalid point is given", ->
+        marker1 = buffer.markPosition([0, 1])
+
+        expect -> buffer.markPosition([0, NaN])
+          .toThrow "Invalid Point: (0, NaN)"
+
+        expect(buffer.findMarkers({})).toEqual [marker1]
+        expect(buffer.getMarkers()).toEqual [marker1]
 
   describe "direct updates", ->
     [marker, changes] = []

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -656,6 +656,15 @@ describe "TextBuffer", ->
       expect(buffer.clipPosition([10, 0])).toEqual [2, 18]
       expect(buffer.clipPosition([Infinity, 0])).toEqual [2, 18]
 
+    it "throws an error when given an invalid point", ->
+      buffer = new TextBuffer(text: "hello\nworld\r\nhow are you doing?")
+      expect -> buffer.clipPosition([NaN, 1])
+        .toThrow("Invalid Point: (NaN, 1)")
+      expect -> buffer.clipPosition([0, NaN])
+        .toThrow("Invalid Point: (0, NaN)")
+      expect -> buffer.clipPosition([0, {}])
+        .toThrow("Invalid Point: (0, [object Object])")
+
   describe "::characterIndexForPosition(position)", ->
     beforeEach ->
       buffer = new TextBuffer(text: "zero\none\r\ntwo\nthree")

--- a/src/marker-index.coffee
+++ b/src/marker-index.coffee
@@ -355,8 +355,6 @@ class MarkerIndex
 
   insert: (id, start, end) ->
     assertValidId(id)
-    assertValidPoint(start)
-    assertValidPoint(end)
     @rangeCache[id] = Range(start, end)
     if splitNodes = @rootNode.insert(new Set().add(id + ""), start, end)
       @rootNode = new Node(splitNodes)
@@ -368,9 +366,6 @@ class MarkerIndex
     @condenseIfNeeded()
 
   splice: (position, oldExtent, newExtent) ->
-    assertValidPoint(position)
-    assertValidPoint(oldExtent)
-    assertValidPoint(newExtent)
     @clearRangeCache()
     if splitNodes = @rootNode.splice(position, oldExtent, newExtent, @exclusiveIds, new Set, new Set)
       @rootNode = new Node(splitNodes)
@@ -472,13 +467,6 @@ class MarkerIndex
 assertValidId = (id) ->
   unless typeof id is 'string'
     throw new TypeError("Marker ID must be a string")
-
-assertValidPoint = (point) ->
-  unless (point instanceof Point) and isNumber(point.row) and isNumber(point.column)
-    throw new TypeError("Invalid Point: #{point}")
-
-isNumber = (number) ->
-  (typeof number is 'number') and not Number.isNaN(number)
 
 templateRange = ->
   Object.create(Range.prototype)

--- a/src/marker-store.coffee
+++ b/src/marker-store.coffee
@@ -203,6 +203,8 @@ class MarkerStore
   ###
 
   addMarker: (id, range, params) ->
+    Point.assertValid(range.start)
+    Point.assertValid(range.end)
     marker = new Marker(id, this, range, params)
     @markersById[id] = marker
     @index.insert(id, range.start, range.end)

--- a/src/point.coffee
+++ b/src/point.coffee
@@ -70,6 +70,10 @@ class Point
     else
       point2
 
+  @assertValid: (point) ->
+    unless isNumber(point.row) and isNumber(point.column)
+      throw new TypeError("Invalid Point: #{point}")
+
   @ZERO: Object.freeze(new Point(0, 0))
 
   @INFINITY: Object.freeze(new Point(Infinity, Infinity))

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1171,6 +1171,7 @@ class TextBuffer
   # the given position.
   clipPosition: (position) ->
     position = Point.fromObject(position)
+    Point.assertValid(position)
     {row, column} = position
     if row < 0
       @getFirstPosition()


### PR DESCRIPTION
I just realized that the validation that I added was not early enough. It prevented the bug I was observing, but it still left the buffer in an inconsistent state.

Refs atom/atom#7077