### PR TITLE
Allow matches at beginning of scanned range in TextBuffer.prototype.backwardsScanInRange

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1906,6 +1906,32 @@ describe "TextBuffer", ->
         expect(matches[2][1]).toBe 'rr'
         expect(ranges[2]).toEqual [[5,6], [5,13]]
 
+    describe "when the last regex match starts at the beginning of the range", ->
+      it "calls the iterator with the match", ->
+        matches = []
+        ranges = []
+        buffer.scanInRange /quick/g, [[0,4], [2,0]], ({match, range}) ->
+          matches.push(match)
+          ranges.push(range)
+
+        expect(matches.length).toBe 1
+        expect(ranges.length).toBe 1
+
+        expect(matches[0][0]).toBe 'quick'
+        expect(ranges[0]).toEqual [[0,4], [0,9]]
+
+        matches = []
+        ranges = []
+        buffer.scanInRange /^/, [[0,0], [2,0]], ({match, range}) ->
+          matches.push(match)
+          ranges.push(range)
+
+        expect(matches.length).toBe 1
+        expect(ranges.length).toBe 1
+
+        expect(matches[0][0]).toBe ""
+        expect(ranges[0]).toEqual [[0,0], [0,0]]
+
     describe "when the iterator calls the 'replace' control function with a replacement string", ->
       it "replaces each occurrence of the regex match with the string", ->
         ranges = []

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1816,7 +1816,7 @@ describe "TextBuffer", ->
           expect(ranges[1]).toEqual [[6,6], [6,9]]
 
       describe "when the portion of the match within the range does not matches the regex", ->
-        it "calls the iterator with the truncated match", ->
+        it "does not call the iterator with the truncated match", ->
           matches = []
           ranges = []
           buffer.scanInRange /cu(r*)e/g, [[4,0], [6,9]], ({match, range}) ->
@@ -1931,6 +1931,41 @@ describe "TextBuffer", ->
 
         expect(matches[0][0]).toBe ""
         expect(ranges[0]).toEqual [[0,0], [0,0]]
+
+    describe "when the first regex match exceeds the end of the range", ->
+      describe "when the portion of the match within the range also matches the regex", ->
+        it "calls the iterator with the truncated match", ->
+          matches = []
+          ranges = []
+          buffer.backwardsScanInRange /cu(r*)/g, [[4,0], [6,9]], ({match, range}) ->
+            matches.push(match)
+            ranges.push(range)
+
+          expect(matches.length).toBe 2
+          expect(ranges.length).toBe 2
+
+          expect(matches[0][0]).toBe 'cur'
+          expect(matches[0][1]).toBe 'r'
+          expect(ranges[0]).toEqual [[6,6], [6,9]]
+
+          expect(matches[1][0]).toBe 'curr'
+          expect(matches[1][1]).toBe 'rr'
+          expect(ranges[1]).toEqual [[5,6], [5,10]]
+
+      describe "when the portion of the match within the range does not matches the regex", ->
+        it "does not call the iterator with the truncated match", ->
+          matches = []
+          ranges = []
+          buffer.backwardsScanInRange /cu(r*)e/g, [[4,0], [6,9]], ({match, range}) ->
+            matches.push(match)
+            ranges.push(range)
+
+          expect(matches.length).toBe 1
+          expect(ranges.length).toBe 1
+
+          expect(matches[0][0]).toBe 'curre'
+          expect(matches[0][1]).toBe 'rr'
+          expect(ranges[0]).toEqual [[5,6], [5,11]]
 
     describe "when the iterator calls the 'replace' control function with a replacement string", ->
       it "replaces each occurrence of the regex match with the string", ->

--- a/src/match-iterator.coffee
+++ b/src/match-iterator.coffee
@@ -27,11 +27,12 @@ class Forwards
 class Backwards
   constructor: (@text, @regex, @startIndex, endIndex, @chunkSize) ->
     @bufferedMatches = []
+    @doneScanning = false
     @chunkStartIndex = @chunkEndIndex = endIndex
     @lastMatchIndex = Infinity
 
   scanNextChunk: ->
-    return false if @chunkStartIndex is @startIndex
+    @doneScanning = @chunkStartIndex is @startIndex
 
     # If results were found in the last chunk, then scan to the beginning
     # of the previous result. Otherwise, continue to scan to the same position
@@ -65,11 +66,11 @@ class Backwards
         @regex.lastIndex = matchEndIndex
 
     @lastMatchIndex = firstResultIndex if firstResultIndex
-    true
 
   next: ->
-    while @bufferedMatches.length is 0
-      break unless @scanNextChunk()
+    until @doneScanning or @bufferedMatches.length > 0
+      @scanNextChunk()
+
     if match = @bufferedMatches.pop()
       {value: match, done: false}
     else


### PR DESCRIPTION
In atom/atom#5806, there's a [hack](https://github.com/atom/atom/pull/5806/files#diff-24f2fe2bd60cb4194c3cf7d107fa0f99R414) when moving to the previous subword boundary to account for the fact that it's impossible to match a regex against the start of the buffer when scanning backwards in a range. This seems unfortunate and unnecessary, especially since we allow regex matches that end at the end of the range. On the other hand, this could cause subtle issues by slightly widening the matches admitted by this method.

@maxbrunsfeld: What do you think?
