### PR TITLE
Default maintainHistory option to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "6.3.11",
+  "version": "6.4.0-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -43,8 +43,8 @@ describe "Marker", ->
         marker = buffer.markRange([[-100, -100], [100, 100]])
         expect(marker.getRange()).toEqual [[0, 0], [0, 26]]
 
-      it "allows markers to opt out of snapshotting for undo/redo", ->
-        marker1 = buffer.markPosition([0, 3])
+      it "allows markers to opt in to snapshotting for undo/redo", ->
+        marker1 = buffer.markPosition([0, 3], maintainHistory: true)
         marker2 = buffer.markPosition([0, 3], maintainHistory: false)
 
         marker1Events = []
@@ -105,7 +105,7 @@ describe "Marker", ->
     [marker, changes] = []
 
     beforeEach ->
-      marker = buffer.markRange([[0, 6], [0, 9]])
+      marker = buffer.markRange([[0, 6], [0, 9]], maintainHistory: true)
       changes = []
       markersUpdatedCount = 0
       marker.onDidChange (change) -> changes.push(change)
@@ -458,7 +458,7 @@ describe "Marker", ->
     [allStrategies, neverMarker, surroundMarker, overlapMarker, insideMarker, touchMarker] = []
 
     beforeEach ->
-      overlapMarker = buffer.markRange([[0, 6], [0, 9]], invalidate: 'overlap')
+      overlapMarker = buffer.markRange([[0, 6], [0, 9]], invalidate: 'overlap', maintainHistory: true)
       neverMarker = overlapMarker.copy(invalidate: 'never')
       surroundMarker = overlapMarker.copy(invalidate: 'surround')
       insideMarker = overlapMarker.copy(invalidate: 'inside')
@@ -849,8 +849,8 @@ describe "Marker", ->
           buffer.append('\n')
           buffer.append('bar')
 
-        marker1 = buffer.markRange([[0, 0], [0, 3]], invalidate: 'never')
-        marker2 = buffer.markRange([[1, 0], [1, 3]], invalidate: 'never')
+        marker1 = buffer.markRange([[0, 0], [0, 3]], invalidate: 'never', maintainHistory: true)
+        marker2 = buffer.markRange([[1, 0], [1, 3]], invalidate: 'never', maintainHistory: true)
 
         marker1Ranges = []
         marker2Ranges = []
@@ -877,7 +877,7 @@ describe "Marker", ->
 
       it "only records marker patches for direct marker updates", ->
         buffer.setText("abcd")
-        marker = buffer.markRange([[0, 3], [0, 3]])
+        marker = buffer.markRange([[0, 3], [0, 3]], maintainHistory: true)
 
         buffer.transact ->
           buffer.delete([[0, 0], [0, 1]])
@@ -890,7 +890,7 @@ describe "Marker", ->
 
     describe "when a marker is updated before undoing or redoing", ->
       it "restores the marker to its state before/after the undone/redone change", ->
-        marker = buffer.markRange([[0, 5], [0, 5]])
+        marker = buffer.markRange([[0, 5], [0, 5]], maintainHistory: true)
 
         buffer.insert([0, 5], "...")
         expect(marker.getRange()).toEqual [[0, 5], [0, 8]]

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -982,7 +982,7 @@ describe "Marker", ->
     beforeEach ->
       marker1 = buffer.markRange([[0, 0], [0, 3]], class: 'a')
       marker2 = buffer.markRange([[0, 0], [0, 5]], class: 'a', invalidate: 'surround')
-      marker3 = buffer.markRange([[0, 4], [0, 7]], class: 'a')
+      marker3 = buffer.markRange([[0, 4], [0, 7]], class: 'a', maintainHistory: true)
       marker4 = buffer.markRange([[0, 0], [0, 7]], class: 'b', invalidate: 'never')
 
     it "can find markers based on custom properties", ->
@@ -993,6 +993,10 @@ describe "Marker", ->
       expect(buffer.findMarkers(invalidate: 'overlap')).toEqual [marker1, marker3]
       expect(buffer.findMarkers(invalidate: 'surround')).toEqual [marker2]
       expect(buffer.findMarkers(invalidate: 'never')).toEqual [marker4]
+
+    it "can find markers based on whether or not their history is maintained", ->
+      expect(buffer.findMarkers(maintainHistory: true)).toEqual [marker3]
+      expect(buffer.findMarkers(maintainHistory: false)).toEqual [marker4, marker2, marker1]
 
     it "can find markers that start or end at a given position", ->
       expect(buffer.findMarkers(startPosition: [0, 0])).toEqual [marker4, marker2, marker1]

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -563,7 +563,7 @@ describe "TextBuffer", ->
           buffer.append("three\n")
           buffer.append("four")
 
-        marker = buffer.markRange([[0, 1], [2, 3]])
+        marker = buffer.markRange([[0, 1], [2, 3]], maintainHistory: true)
         result = buffer.groupChangesSinceCheckpoint(checkpoint)
 
         expect(result).toBe true

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -51,7 +51,7 @@ class Marker
     @valid ?= true
     @invalidate ?= 'overlap'
     @persistent ?= true
-    @maintainHistory ?= true
+    @maintainHistory ?= false
     @properties ?= {}
     @hasChangeObservers = false
     @rangeWhenDestroyed = null

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -324,7 +324,7 @@ class Marker
         @getEndPosition().row is value
       when 'intersectsRow'
         @intersectsRow(value)
-      when 'invalidate', 'reversed', 'tailed', 'persistent'
+      when 'invalidate', 'reversed', 'tailed', 'persistent', 'maintainHistory'
         isEqual(@[key], value)
       else
         isEqual(@properties[key], value)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -773,11 +773,17 @@ class TextBuffer
   # * `range` A {Range} or range-compatible {Array}
   # * `properties` A hash of key-value pairs to associate with the marker. There
   #   are also reserved property names that have marker-specific meaning.
-  #   * `reversed` (optional) Creates the marker in a reversed orientation. (default: false)
-  #   * `persistent` (optional) Whether to include this marker when serializing the buffer. (default: true)
-  #   * `invalidate` (optional) Determines the rules by which changes to the
-  #     buffer *invalidate* the marker. (default: 'overlap') It can be any of
-  #     the following strategies, in order of fragility
+  #   * `maintainHistory` (optional) {Boolean} Whether to store this marker's
+  #     range before and after each change in the undo history. This allows the
+  #     marker's position to be restored more accurately for certain undo/redo
+  #     operations, but uses more time and memory. (default: false)
+  #   * `reversed` (optional) {Boolean} Creates the marker in a reversed
+  #     orientation. (default: false)
+  #   * `persistent` (optional) {Boolean} Whether to include this marker when
+  #     serializing the buffer. (default: true)
+  #   * `invalidate` (optional) {String} Determines the rules by which changes
+  #     to the buffer *invalidate* the marker. (default: 'overlap') It can be
+  #     any of the following strategies, in order of fragility:
   #     * __never__: The marker is never marked as invalid. This is a good choice for
   #       markers representing selections in an editor.
   #     * __surround__: The marker is invalidated by changes that completely surround it.


### PR DESCRIPTION
Snapshotting markers uses a lot of time and memory. It is not necessary for must use cases, because markers are recreated or updated automatically on every buffer change anyway. This changes the default value of the `maintainHistory` option to `false`.

In Atom, we'll need to specify `maintainHistory: true` for selections.