### PR TITLE
Add option to save a backup file before saving buffer

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1759,13 +1759,16 @@ describe "TextBuffer", ->
 
         describe "if a file already exists at the default backup path", ->
           it "chooses a different backup file name to avoid overwriting the existing file", ->
+            alternateBackupFilePath = backupFilePath + '~'
+            fs.removeSync(alternateBackupFilePath) if fs.existsSync(alternateBackupFilePath)
+
             fs.writeFileSync(backupFilePath, 'Contents of file at default backup path')
 
             saveAsBuffer.saveAs(filePath, backup: true)
             expect(fs.readFileSync(filePath, 'utf8')).toBe 'Buffer contents'
             expect(fs.readFileSync(backupFilePath, 'utf8')).toBe 'Contents of file at default backup path'
             expect(fs.existsSync(backupFilePath)).toBe true
-            expect(fs.existsSync(backupFilePath + '~')).toBe false
+            expect(fs.existsSync(alternateBackupFilePath)).toBe false
 
 
       describe "if no file exists at the path", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1,10 +1,10 @@
-{existsSync, moveSync, readFileSync, removeSync, writeFileSync} = require 'fs-plus'
+fs = require 'fs-plus'
 {join} = require 'path'
 temp = require 'temp'
 {File} = require 'pathwatcher'
 Random = require 'random-seed'
 TextBuffer = require '../src/text-buffer'
-SampleText = readFileSync(join(__dirname, 'fixtures', 'sample.js'), 'utf8')
+SampleText = fs.readFileSync(join(__dirname, 'fixtures', 'sample.js'), 'utf8')
 
 describe "TextBuffer", ->
   buffer = null
@@ -59,16 +59,16 @@ describe "TextBuffer", ->
 
       describe "when a file exists for the path", ->
         it "loads the contents of that file", ->
-          expect(buffer.getText()).toBe readFileSync(filePath, 'utf8')
+          expect(buffer.getText()).toBe fs.readFileSync(filePath, 'utf8')
 
         it "does not allow the initial state of the buffer to be undone", ->
           buffer.undo()
-          expect(buffer.getText()).toBe readFileSync(filePath, 'utf8')
+          expect(buffer.getText()).toBe fs.readFileSync(filePath, 'utf8')
 
       describe "when no file exists for the path", ->
         it "is not modified and is initially empty", ->
           filePath = "does-not-exist.txt"
-          expect(existsSync(filePath)).toBeFalsy()
+          expect(fs.existsSync(filePath)).toBeFalsy()
           buffer = new TextBuffer({filePath, load: true})
           expect(buffer.isModified()).not.toBeTruthy()
           expect(buffer.getText()).toBe ''
@@ -837,7 +837,7 @@ describe "TextBuffer", ->
 
       beforeEach ->
         filePath = temp.openSync('atom').path
-        writeFileSync(filePath, "words")
+        fs.writeFileSync(filePath, "words")
         buffer = new TextBuffer({filePath, load: true})
 
         waitsFor ->
@@ -864,7 +864,7 @@ describe "TextBuffer", ->
         describe "when the disk contents were changed since serialization", ->
           it "loads the disk contents instead of the previous unsaved state", ->
             buffer.setText("BUFFER CHANGE")
-            writeFileSync(filePath, "DISK CHANGE")
+            fs.writeFileSync(filePath, "DISK CHANGE")
 
             buffer2 = buffer.testSerialization()
 
@@ -937,7 +937,7 @@ describe "TextBuffer", ->
     beforeEach ->
       filePath = join(__dirname, "fixtures", "manipulate-me")
       newPath = "#{filePath}-i-moved"
-      writeFileSync(filePath, "")
+      fs.writeFileSync(filePath, "")
       bufferToChange = new TextBuffer({filePath, load: true})
       eventHandler = jasmine.createSpy('eventHandler')
       bufferToChange.onDidChangePath eventHandler
@@ -947,16 +947,16 @@ describe "TextBuffer", ->
 
     afterEach ->
       bufferToChange.destroy()
-      removeSync(filePath)
-      removeSync(newPath)
+      fs.removeSync(filePath)
+      fs.removeSync(newPath)
 
     it "notifies observers when the buffer is saved to a new path", ->
       bufferToChange.saveAs(newPath)
       expect(eventHandler).toHaveBeenCalledWith(newPath)
 
     it "notifies observers when the buffer's file is moved", ->
-      removeSync(newPath)
-      moveSync(filePath, newPath)
+      fs.removeSync(newPath)
+      fs.moveSync(filePath, newPath)
 
       waitsFor "buffer path change", ->
         eventHandler.callCount > 0
@@ -969,7 +969,7 @@ describe "TextBuffer", ->
 
     beforeEach ->
       filePath = join(__dirname, "fixtures", "manipulate-me")
-      writeFileSync(filePath, "")
+      fs.writeFileSync(filePath, "")
       bufferToChange = new TextBuffer({filePath, load: true})
       eventHandler = jasmine.createSpy('eventHandler')
       bufferToChange.onWillThrowWatchError eventHandler
@@ -979,7 +979,7 @@ describe "TextBuffer", ->
 
     afterEach ->
       bufferToChange.destroy()
-      removeSync(filePath)
+      fs.removeSync(filePath)
 
     it "notifies observers when the file has a watch error", ->
       bufferToChange.file.emitter.emit 'will-throw-watch-error', 'arg'
@@ -990,7 +990,7 @@ describe "TextBuffer", ->
 
     beforeEach ->
       filePath = temp.openSync('atom').path
-      writeFileSync(filePath, "first")
+      fs.writeFileSync(filePath, "first")
       buffer = new TextBuffer({filePath, load: true})
 
       waitsFor ->
@@ -1013,7 +1013,7 @@ describe "TextBuffer", ->
       it "changes the in-memory contents of the buffer to match the new disk contents and notifies ::onDidChange observers", ->
         changeHandler = jasmine.createSpy('changeHandler')
         buffer.onDidChange changeHandler
-        writeFileSync(filePath, "second")
+        fs.writeFileSync(filePath, "second")
 
         expect(changeHandler.callCount).toBe 0
         waitsFor "file to trigger change event", ->
@@ -1040,7 +1040,7 @@ describe "TextBuffer", ->
         buffer.file.onDidChange fileChangeHandler
 
         buffer.insert([0, 0], "a change")
-        writeFileSync(filePath, "second")
+        fs.writeFileSync(filePath, "second")
 
         expect(fileChangeHandler.callCount).toBe 0
         waitsFor "file to notify ::onDidChange observer", ->
@@ -1055,7 +1055,7 @@ describe "TextBuffer", ->
         buffer.insert([0, 0], "a second change")
 
         handler = jasmine.createSpy('fileChange')
-        writeFileSync(filePath, "a disk change")
+        fs.writeFileSync(filePath, "a disk change")
         buffer.onDidConflict handler
 
         expect(handler.callCount).toBe 0
@@ -1070,7 +1070,7 @@ describe "TextBuffer", ->
 
     beforeEach ->
       filePath = join(temp.dir, 'atom-file-to-delete.txt')
-      writeFileSync(filePath, 'delete me')
+      fs.writeFileSync(filePath, 'delete me')
       bufferToDelete = new TextBuffer({filePath, load: true})
       filePath = bufferToDelete.getPath() # symlinks may have been converted
       expect(bufferToDelete.getPath()).toBe filePath
@@ -1088,7 +1088,7 @@ describe "TextBuffer", ->
 
         deleteHandler = jasmine.createSpy('deleteHandler')
         bufferToDelete.file.onDidDelete deleteHandler
-        removeSync(filePath)
+        fs.removeSync(filePath)
         waitsFor "file to be deleted", ->
           deleteHandler.callCount > 0
 
@@ -1102,7 +1102,7 @@ describe "TextBuffer", ->
 
         deleteHandler = jasmine.createSpy('deleteHandler')
         bufferToDelete.file.onDidDelete deleteHandler
-        removeSync(filePath)
+        fs.removeSync(filePath)
         waitsFor "file to be deleted", ->
           deleteHandler.callCount > 0
 
@@ -1115,17 +1115,17 @@ describe "TextBuffer", ->
       it "notifies all onDidDelete listeners ", ->
         deleteHandler = jasmine.createSpy('deleteHandler')
         bufferToDelete.onDidDelete deleteHandler
-        removeSync(filePath)
+        fs.removeSync(filePath)
 
         waitsFor "file to be deleted", ->
           deleteHandler.callCount is 1
 
     it "resumes watching of the file when it is re-saved", ->
       bufferToDelete.save()
-      expect(existsSync(bufferToDelete.getPath())).toBeTruthy()
+      expect(fs.existsSync(bufferToDelete.getPath())).toBeTruthy()
       expect(bufferToDelete.isInConflict()).toBeFalsy()
 
-      writeFileSync(filePath, 'moo')
+      fs.writeFileSync(filePath, 'moo')
 
       changeHandler = jasmine.createSpy('changeHandler')
       bufferToDelete.onDidChange changeHandler
@@ -1137,7 +1137,7 @@ describe "TextBuffer", ->
 
     beforeEach ->
       filePath = join(temp.dir, 'atom-tmp-file')
-      writeFileSync(filePath, '')
+      fs.writeFileSync(filePath, '')
       buffer = new TextBuffer({filePath, load: true})
 
       waitsFor ->
@@ -1234,8 +1234,8 @@ describe "TextBuffer", ->
 
     it "reports the modified status changing to false after a buffer to a non-existent file is saved", ->
       buffer.destroy()
-      removeSync(filePath)
-      expect(existsSync(filePath)).toBeFalsy()
+      fs.removeSync(filePath)
+      expect(fs.existsSync(filePath)).toBeFalsy()
 
       buffer = new TextBuffer({filePath, load: true})
       modifiedHandler = jasmine.createSpy("modifiedHandler")
@@ -1256,7 +1256,7 @@ describe "TextBuffer", ->
         modifiedHandler.reset()
         buffer.save()
 
-        expect(existsSync(filePath)).toBeTruthy()
+        expect(fs.existsSync(filePath)).toBeTruthy()
         expect(modifiedHandler).toHaveBeenCalledWith(false)
         expect(buffer.isModified()).toBe false
 
@@ -1307,7 +1307,7 @@ describe "TextBuffer", ->
   describe "::getLines()", ->
     it "returns an array of lines in the text contents", ->
       filePath = require.resolve('./fixtures/sample.js')
-      fileContents = readFileSync(filePath, 'utf8')
+      fileContents = fs.readFileSync(filePath, 'utf8')
       buffer = new TextBuffer({filePath, load: true})
 
       waitsFor ->
@@ -1322,7 +1322,7 @@ describe "TextBuffer", ->
 
     beforeEach ->
       filePath = require.resolve('./fixtures/sample.js')
-      fileContents = readFileSync(filePath, 'utf8')
+      fileContents = fs.readFileSync(filePath, 'utf8')
       buffer = new TextBuffer({filePath, load: true})
 
       waitsFor ->
@@ -1585,7 +1585,7 @@ describe "TextBuffer", ->
 
       beforeEach ->
         filePath = join(temp.dir, 'temp.txt')
-        writeFileSync(filePath, "")
+        fs.writeFileSync(filePath, "")
         saveBuffer = new TextBuffer({filePath, load: true})
 
         waitsFor ->
@@ -1597,7 +1597,7 @@ describe "TextBuffer", ->
       it "saves the contents of the buffer to the path", ->
         saveBuffer.setText 'Buffer contents!'
         saveBuffer.save()
-        expect(readFileSync(filePath, 'utf8')).toEqual 'Buffer contents!'
+        expect(fs.readFileSync(filePath, 'utf8')).toEqual 'Buffer contents!'
 
       it "notifies ::onWillSave and ::onDidSave observers around the call to File::writeSync", ->
         events = []
@@ -1635,7 +1635,7 @@ describe "TextBuffer", ->
         saveBuffer.save()
         saveBuffer.setText('ab')
 
-        writeFileSync(saveBuffer.getPath(), 'c')
+        fs.writeFileSync(saveBuffer.getPath(), 'c')
         conflictHandler = jasmine.createSpy('conflictHandler')
         saveBuffer.onDidConflict conflictHandler
 
@@ -1661,7 +1661,7 @@ describe "TextBuffer", ->
   describe "reload()", ->
     it "reloads current text from disk and clears any conflicts", ->
       filePath = require.resolve('./fixtures/sample.js')
-      fileContents = readFileSync(filePath, 'utf8')
+      fileContents = fs.readFileSync(filePath, 'utf8')
       buffer = new TextBuffer({filePath, load: true})
 
       waitsFor ->
@@ -1684,7 +1684,7 @@ describe "TextBuffer", ->
 
     it "saves the contents of the buffer to the path", ->
       filePath = join(temp.dir, 'temp.txt')
-      removeSync(filePath)
+      fs.removeSync(filePath)
 
       saveAsBuffer = new TextBuffer()
       eventHandler = jasmine.createSpy('eventHandler')
@@ -1692,7 +1692,7 @@ describe "TextBuffer", ->
 
       saveAsBuffer.setText 'Buffer contents!'
       saveAsBuffer.saveAs(filePath)
-      expect(readFileSync(filePath, 'utf8')).toEqual 'Buffer contents!'
+      expect(fs.readFileSync(filePath, 'utf8')).toEqual 'Buffer contents!'
 
       expect(eventHandler).toHaveBeenCalledWith(filePath)
 
@@ -1700,7 +1700,7 @@ describe "TextBuffer", ->
       changeHandler = null
       originalPath = join(temp.dir, 'original.txt')
       newPath = join(temp.dir, 'new.txt')
-      writeFileSync(originalPath, "")
+      fs.writeFileSync(originalPath, "")
 
       saveAsBuffer = new TextBuffer({filePath: originalPath, load: true})
 
@@ -1713,13 +1713,13 @@ describe "TextBuffer", ->
         saveAsBuffer.saveAs(newPath)
         expect(changeHandler).not.toHaveBeenCalled()
 
-        writeFileSync(originalPath, "should not trigger buffer event")
+        fs.writeFileSync(originalPath, "should not trigger buffer event")
 
       waits 20
 
       runs ->
         expect(changeHandler).not.toHaveBeenCalled()
-        writeFileSync(newPath, "should trigger buffer event")
+        fs.writeFileSync(newPath, "should trigger buffer event")
 
       waitsFor ->
         changeHandler.callCount > 0

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1770,7 +1770,6 @@ describe "TextBuffer", ->
             expect(fs.existsSync(backupFilePath)).toBe true
             expect(fs.existsSync(alternateBackupFilePath)).toBe false
 
-
       describe "if no file exists at the path", ->
         it "does not make a backup before writing", ->
           fs.removeSync(filePath) if fs.existsSync(filePath)

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1745,7 +1745,7 @@ describe "TextBuffer", ->
             expect(fs.existsSync(backupFilePath)).toBe false
 
         describe "if an exception is thrown while writing to the file", ->
-          it "restores the file's original contents from the backup copy, deletes the backup copy, and re-throws the exception", ->
+          it "restores the file's original contents from the backup copy, preserves the backup copy just in case, and re-throws the exception", ->
             saveAsBuffer.setPath(filePath)
             originalWriteSync = saveAsBuffer.file.writeSync
             saveAsBuffer.file.writeSync = (args...) ->
@@ -1755,7 +1755,7 @@ describe "TextBuffer", ->
             expect(-> saveAsBuffer.saveAs(filePath, backup: true)).toThrow 'Something broke'
 
             expect(fs.readFileSync(filePath, 'utf8')).toBe 'File contents'
-            expect(fs.existsSync(backupFilePath)).toBe false
+            expect(fs.existsSync(backupFilePath)).toBe true
 
         describe "if a file already exists at the default backup path", ->
           it "chooses a different backup file name to avoid overwriting the existing file", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1732,6 +1732,7 @@ describe "TextBuffer", ->
         saveAsBuffer = new TextBuffer()
         saveAsBuffer.setText 'Buffer contents'
         backupFilePath = filePath + '~'
+        fs.removeSync(backupFilePath) if fs.existsSync(backupFilePath)
 
       describe "if there is an existing file at the specified path", ->
         beforeEach ->
@@ -1755,6 +1756,17 @@ describe "TextBuffer", ->
 
             expect(fs.readFileSync(filePath, 'utf8')).toBe 'File contents'
             expect(fs.existsSync(backupFilePath)).toBe false
+
+        describe "if a file already exists at the default backup path", ->
+          it "chooses a different backup file name to avoid overwriting the existing file", ->
+            fs.writeFileSync(backupFilePath, 'Contents of file at default backup path')
+
+            saveAsBuffer.saveAs(filePath, backup: true)
+            expect(fs.readFileSync(filePath, 'utf8')).toBe 'Buffer contents'
+            expect(fs.readFileSync(backupFilePath, 'utf8')).toBe 'Contents of file at default backup path'
+            expect(fs.existsSync(backupFilePath)).toBe true
+            expect(fs.existsSync(backupFilePath + '~')).toBe false
+
 
       describe "if no file exists at the path", ->
         it "does not make a backup before writing", ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1230,7 +1230,6 @@ class TextBuffer
     catch error
       if backupFilePath?
         fs.writeFileSync(filePath, fs.readFileSync(backupFilePath))
-        fs.removeSync(backupFilePath)
       throw error
 
     @cachedDiskContents = @getText()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1219,7 +1219,8 @@ class TextBuffer
 
     try
       @file.writeSync(@getText())
-      @removeBackupFileAfterWriting(backupFilePath) if backupFilePath?
+      if backupFilePath?
+        @removeBackupFileAfterWriting(backupFilePath)
     catch error
       if backupFilePath?
         fs.writeFileSync(filePath, fs.readFileSync(backupFilePath))

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1215,6 +1215,7 @@ class TextBuffer
 
     if options?.backup and @file.existsSync()
       backupFilePath = filePath + '~'
+      backupFilePath += '~' while fs.existsSync(backupFilePath)
       fs.writeFileSync(backupFilePath, @file.readSync())
 
     try

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1215,7 +1215,7 @@ class TextBuffer
     @setPath(filePath)
 
     if options?.backup
-      backupFilePath = @backupFileContentsBeforeWriting()
+      backupFilePath = @backUpFileContentsBeforeWriting()
 
     try
       @file.writeSync(@getText())
@@ -1257,7 +1257,7 @@ class TextBuffer
       @cachedDiskContents = contents
       callback?()
 
-  backupFileContentsBeforeWriting: ->
+  backUpFileContentsBeforeWriting: ->
     return unless @file.existsSync()
 
     backupFilePath = @getPath() + '~'

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1264,7 +1264,6 @@ class TextBuffer
       @cachedDiskContents = contents
       callback?()
 
-  # Creates a backup file for the given path when writing.
   backupFileContentsBeforeWriting: ->
     return unless @file.existsSync()
 
@@ -1273,11 +1272,11 @@ class TextBuffer
     backupFD = fs.openSync(backupFilePath, 'w')
     fs.writeSync(backupFD, @file.readSync())
 
-    # ensure backup file contents are really on disk before proceeding
+    # Ensure backup file contents are really on disk before proceeding
     fs.fdatasyncSync(backupFD)
     fs.closeSync(backupFD)
 
-    # ensure backup file directory entry is really on disk before proceeding
+    # Ensure backup file directory entry is really on disk before proceeding
     backupDirectoryFD = fs.openSync(path.dirname(backupFilePath), 'r')
     fs.fdatasyncSync(backupDirectoryFD)
     fs.closeSync(backupDirectoryFD)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1220,11 +1220,12 @@ class TextBuffer
 
     try
       @file.writeSync(@getText())
-    catch error
-      fs.writeFileSync(filePath, fs.readFileSync(backupFilePath)) if backupFilePath?
-      throw error
-    finally
       fs.removeSync(backupFilePath) if backupFilePath?
+    catch error
+      if backupFilePath?
+        fs.writeFileSync(filePath, fs.readFileSync(backupFilePath))
+        fs.removeSync(backupFilePath)
+      throw error
 
     @cachedDiskContents = @getText()
     @conflict = false

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1261,7 +1261,13 @@ class TextBuffer
     return unless @file.existsSync()
 
     backupFilePath = @getPath() + '~'
-    backupFilePath += '~' while fs.existsSync(backupFilePath)
+
+    maxTildes = 10
+    while fs.existsSync(backupFilePath)
+      if --maxTildes is 0
+        throw new Error("Can't create a backup file for #{@getPath()} because files already exist at every candidate path.")
+      backupFilePath += '~'
+
     backupFD = fs.openSync(backupFilePath, 'w')
     fs.writeSync(backupFD, @file.readSync())
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1200,8 +1200,8 @@ class TextBuffer
   ###
 
   # Public: Save the buffer.
-  save: ->
-    @saveAs(@getPath())
+  save: (options) ->
+    @saveAs(@getPath(), options)
 
   # Public: Save the buffer at a specific path.
   #


### PR DESCRIPTION
Refs atom/atom#3158

When writing directly to an existing file, it's possible to truncate the original file if an I/O error occurs during the write. This PR adds the option to save a backup file to the path of the original file with a `~` appended. If any exceptions occur, we restore from the backup and delete it.

I'm honestly not super well-versed in all the nuances of safely writing files... I'm interested in input on this. I realize that buffering the entire file through memory before writing the backup isn't that awesome, but I'm not sure there's a synchronous cross-platform alternative. I'm really wishing `saveAs` was asynchronous right now...

Also: Does anyone know if Node's `writeFileSync` method does an `fsync` automatically?