### PR TITLE
Use native promises instead of Q library

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "grim": "^1.2.1",
     "interval-skip-list": "^2.0.1",
     "pathwatcher": "^4.2",
-    "q": "^1.1.2",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.2.0",
     "underscore-plus": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.2.1",
     "interval-skip-list": "^2.0.1",
-    "pathwatcher": "^4.2",
+    "pathwatcher": "^5.0.0",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.2.0",
     "underscore-plus": "^1.0.0"

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -4,7 +4,6 @@ Serializable = require 'serializable'
 {File} = require 'pathwatcher'
 SpanSkipList = require 'span-skip-list'
 diff = require 'atom-diff'
-Q = require 'q'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
@@ -1262,7 +1261,12 @@ class TextBuffer
   # * `callback`   (optional) {Function} to call after the cached contents have
   #                been updated.
   updateCachedDiskContents: (flushCache=false, callback) ->
-    Q(@file?.read(flushCache) ? "").then (contents) =>
+    if @file?
+      promise = @file.read(flushCache)
+    else
+      promise = Promise.resolve("")
+
+    promise.then (contents) =>
       @cachedDiskContents = contents
       callback?()
 


### PR DESCRIPTION
This is blocked on https://github.com/atom/node-pathwatcher/pull/79 being merged and v0.5.0 of `pathwatcher` being published.