### PR TITLE
RFC: allow special case Infinity grouping interval

### DIFF
--- a/src/history.coffee
+++ b/src/history.coffee
@@ -83,7 +83,7 @@ class History
       if entry instanceof GroupStart
         previousEntry = @undoStack[i - 1]
         if previousEntry instanceof GroupEnd
-          if (topEntry.timestamp - previousEntry.timestamp < Math.min(previousEntry.groupingInterval, groupingInterval))
+          if (topEntry.timestamp - previousEntry.timestamp < Math.min(previousEntry.groupingInterval, groupingInterval)) or (previousEntry.groupingInterval is Infinity)
             @undoStack.splice(i - 1, 2)
         return
 


### PR DESCRIPTION
This is a tentative PR for a feature that I think will benefit the vim-mode package (cf. atom/vim-mode#849). A change with `groupingInterval` of `Infinity` will group with any change coming after it (provided that one has non-0 `groupingInterval`), no matter how long it takes.

The rationale: in vim-mode, the command `ciwabc<escape>` will change (`c`) the current word (`iw`) to the text `abc`. An experienced VIM user will expect a single undo both to remove the `abc` and to restore the current word as it was, but it's also common that there's a break between the change command `ciw` and the typed text `abc` because they are cognitively different chunks of typing.

With this PR, vim-mode could group the deletion of the current word with the `abc` (provided that was typed fast enough for the default 300ms grouping interval), and experienced VIM users would get the benefit of undoing the semantically related changes together (makes sense in vim-mode), and still using the normal timed grouping of undo for text changes (makes sense in modern text editors).

To make sure those `Infinity`-grouped commands don't accidentally get grouped with changes that don't belong in a group, vim-mode can do an empty transaction with 0 grouping interval (as done in atom/vim-mode#849):
```
@editor.transact 0, -> # nothing
```

We can't easily use `groupChangesSinceCheckpoint` because there's no good way of knowing when to trigger it (at least I haven't found one).

I can add specs if you like the general idea.