### PR TITLE
Don't save to existing location if not modified

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1218,6 +1218,8 @@ class TextBuffer
 
   # Public: Save the buffer.
   save: (options) ->
+    return unless @isModified()
+    
     @saveAs(@getPath(), options)
 
   # Public: Save the buffer at a specific path.


### PR DESCRIPTION
Holding down cmd-S too long will cause multiple synchronous saves which can be expensive if there is heavyweight linter activity listening for the save events.

This simply debounces it (in a sense) by not saving it the file if it is known not to have changed. Also this has no effect on saving new files for the first time.