### PR TITLE
Always use serialized text when deserializing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "6.7.1",
+  "version": "6.7.2-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.2.1",
     "interval-skip-list": "^2.0.1",
-    "pathwatcher": "^4.2",
+    "pathwatcher": "4.4.5-0",
     "q": "^1.1.2",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.2.1",
     "interval-skip-list": "^2.0.1",
-    "pathwatcher": "^5.0.0",
+    "pathwatcher": "^5.0.1",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.2.0",
     "underscore-plus": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "6.7.2-3",
+  "version": "6.7.2-4",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "6.7.2-0",
+  "version": "6.7.2-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "6.7.2-2",
+  "version": "6.7.2-3",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "6.7.2-1",
+  "version": "6.7.2-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -866,6 +866,8 @@ describe "TextBuffer", ->
 
       describe "when the serialized buffer had no unsaved changes", ->
         it "loads the current contents of the file at the serialized path", ->
+          buffer.append("!")
+          buffer.save()
           expect(buffer.isModified()).toBeFalsy()
           buffer2 = buffer.testSerialization()
 
@@ -875,6 +877,10 @@ describe "TextBuffer", ->
           runs ->
             expect(buffer2.isModified()).toBeFalsy()
             expect(buffer2.getPath()).toBe(buffer.getPath())
+            expect(buffer2.getText()).toBe(buffer.getText())
+
+            buffer.undo()
+            buffer2.undo()
             expect(buffer2.getText()).toBe(buffer.getText())
 
       describe "when the serialized buffer had unsaved changes", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -328,6 +328,35 @@ describe "TextBuffer", ->
       buffer.undo()
       expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
 
+    it "does not allow the undo stack to grow without bound", ->
+      buffer = new TextBuffer(maxUndoEntries: 12)
+
+      # A transaction with 1 change uses 3 undo entries, so we can undo 4 of
+      # these transactions.
+      for i in [1...10]
+        buffer.append("#{i}\n")
+      expect(buffer.getLineCount()).toBe 10
+
+      undoCount = 0
+      undoCount++ while buffer.undo()
+      expect(undoCount).toBe 4
+      expect(buffer.getLineCount()).toBe 6
+
+      # A transaction with 2 changes uses 4 undo entries, so we can undo 3 of
+      # these transactions.
+      buffer.setText("")
+      buffer.clearUndoStack()
+      for i in [1...10]
+        buffer.transact ->
+          buffer.append(String(i))
+          buffer.append("\n")
+      expect(buffer.getLineCount()).toBe 10
+
+      undoCount = 0
+      undoCount++ while buffer.undo()
+      expect(undoCount).toBe 3
+      expect(buffer.getLineCount()).toBe 7
+
   describe "transactions", ->
     now = null
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -108,7 +108,7 @@ class TextBuffer
     @digestWhenLastPersisted = params?.digestWhenLastPersisted ? false
 
     @setPath(params.filePath) if params?.filePath
-    @load(true) if params?.load
+    @load() if params?.load
 
   # Called by {Serializable} mixin during deserialization.
   deserializeParams: (params) ->
@@ -1322,16 +1322,16 @@ class TextBuffer
     @updateCachedDiskContentsSync()
     @finishLoading()
 
-  load: (clearHistory=false) ->
-    @updateCachedDiskContents().then => @finishLoading(clearHistory)
+  load: ->
+    @updateCachedDiskContents().then => @finishLoading()
 
-  finishLoading: (clearHistory) ->
+  finishLoading: ->
     if @isAlive()
       @loaded = true
       if @digestWhenLastPersisted is @file?.getDigestSync()
         @emitModifiedStatusChanged(true)
       else
-        @reload(clearHistory)
+        @reload(true)
     this
 
   destroy: ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1252,7 +1252,7 @@ class TextBuffer
     @emit 'will-reload' if Grim.includeDeprecatedAPIs
     if clearHistory
       @clearUndoStack()
-      @setTextInRange(@getRange(), @cachedDiskContents, normalizeLineEndings: false, undo: 'skip')
+      @setTextInRange(@getRange(), @cachedDiskContents ? "", normalizeLineEndings: false, undo: 'skip')
     else
       @setTextViaDiff(@cachedDiskContents)
     @emitModifiedStatusChanged(false)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -78,6 +78,7 @@ class TextBuffer
   refcount: 0
   fileSubscriptions: null
   backwardsScanChunkSize: 8000
+  defaultMaxUndoEntries: 10000
   changeCount: 0
 
   ###
@@ -98,7 +99,8 @@ class TextBuffer
     @lineEndings = ['']
     @offsetIndex = new SpanSkipList('rows', 'characters')
     @setTextInRange([[0, 0], [0, 0]], text ? params?.text ? '', normalizeLineEndings: false)
-    @history = params?.history ? new History(this)
+    maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
+    @history = params?.history ? new History(this, maxUndoEntries)
     @markerStore = params?.markerStore ? new MarkerStore(this)
     @setEncoding(params?.encoding)
     @setPreferredLineEnding(params?.preferredLineEnding)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -106,7 +106,6 @@ class TextBuffer
     @loaded = false
     @transactCallDepth = 0
     @digestWhenLastPersisted = params?.digestWhenLastPersisted ? false
-    @modifiedWhenLastPersisted = params?.modifiedWhenLastPersisted ? false
 
     @setPath(params.filePath) if params?.filePath
     @load(true) if params?.load
@@ -125,7 +124,6 @@ class TextBuffer
     history: @history.serialize()
     encoding: @getEncoding()
     filePath: @getPath()
-    modifiedWhenLastPersisted: @isModified()
     digestWhenLastPersisted: @file?.getDigestSync()
     preferredLineEnding: @preferredLineEnding
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -107,7 +107,6 @@ class TextBuffer
     @transactCallDepth = 0
     @digestWhenLastPersisted = params?.digestWhenLastPersisted ? false
     @modifiedWhenLastPersisted = params?.modifiedWhenLastPersisted ? false
-    @useSerializedText = @modifiedWhenLastPersisted isnt false
 
     @setPath(params.filePath) if params?.filePath
     @load(true) if params?.load
@@ -1331,7 +1330,7 @@ class TextBuffer
   finishLoading: (clearHistory) ->
     if @isAlive()
       @loaded = true
-      if @useSerializedText and @digestWhenLastPersisted is @file?.getDigestSync()
+      if @digestWhenLastPersisted is @file?.getDigestSync()
         @emitModifiedStatusChanged(true)
       else
         @reload(clearHistory)


### PR DESCRIPTION
I realized that the fix added in #95 doesn't always work. When the file was saved, the undo history was still lost on reload. This fixes that.

* [ ] Since undo stack is now preserved when reopening a window, it is more likely to get long enough to cause memory usage issues. Introduce some fixed maximum length for the undo stack.

Depends on https://github.com/atom/node-pathwatcher/pull/85