### PR TITLE
Partially fixes compatibility with Node 4.0.0 (update pathwatcher@6.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
     "temp": "~0.6.0"
   },
   "dependencies": {
-    "delegato": "^1.0.0",
     "atom-diff": "^2",
+    "delegato": "^1.0.0",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",
     "grim": "^1.2.1",
     "interval-skip-list": "^2.0.1",
-    "pathwatcher": "^5.0.1",
+    "pathwatcher": "^6.2.0",
     "serializable": "^1.0.0",
     "span-skip-list": "~0.2.0",
     "underscore-plus": "^1.0.0"


### PR DESCRIPTION
This should mostly fix compatibility issues with Node 4.0.0. Still getting a strange error with runas:
```
 17:33:04  dan@elise:~/stuff/text-buffer   node-4.0.0 ✔ 
$ npm install
npm WARN package.json text-buffer@7.0.2 No license field.

> runas@3.1.0 install /Users/dan/stuff/text-buffer/node_modules/pathwatcher/node_modules/runas
> node-gyp rebuild

  CXX(target) Release/obj.target/runas/src/main.o
In file included from ../src/main.cc:1:
../../nan/nan.h:182:11: fatal error: 'nan_maybe_43_inl.h' file not found
# include "nan_maybe_43_inl.h"  // NOLINT(build/include)
          ^
1 error generated.
make: *** [Release/obj.target/runas/src/main.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Darwin 14.5.0
gyp ERR! command "/usr/local/bin/iojs" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/dan/stuff/text-buffer/node_modules/pathwatcher/node_modules/runas
gyp ERR! node -v v4.0.0
gyp ERR! node-gyp -v v2.0.2
gyp ERR! not ok
npm WARN installMany asserts.js was bundled with testla@0.1.3, but bundled package wasn't found in unpacked tree
npm WARN installMany fn.js was bundled with testla@0.1.3, but bundled package wasn't found in unpacked tree
npm WARN installMany observer.js was bundled with testla@0.1.3, but bundled package wasn't found in unpacked tree

> coffeelint@0.5.7 install /Users/dan/stuff/text-buffer/node_modules/grunt-coffeelint/node_modules/coffeelint
> [ -e lib/commandline.js ] || npm run compile

npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "install"
npm ERR! node v4.0.0
npm ERR! npm  v2.14.3
npm ERR! code ELIFECYCLE

npm ERR! runas@3.1.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the runas@3.1.0 install script 'node-gyp rebuild'.
npm ERR! This is most likely a problem with the runas package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls runas
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/dan/stuff/text-buffer/npm-debug.log
```