### PR TITLE
Add MarkerLayer APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "7.2.0-pre-marker-layers.1",
+  "version": "7.2.0-pre-marker-layers.2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "7.1.3",
+  "version": "7.2.0-pre-marker-layers.1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -1110,3 +1110,25 @@ describe "Marker", ->
         expect(buffer.findMarkers(containsPoint: [0, 4])).toEqual [defaultMarker]
         expect(layer1.findMarkers(containsPoint: [0, 4])).toEqual [layer1Marker]
         expect(layer2.findMarkers(containsPoint: [0, 4])).toEqual [layer2Marker]
+
+    describe "::onDidUpdate", ->
+      it "notifies observers asynchronously when markers are created, updated, or destroyed", ->
+        updateCount = 0
+        layer1.onDidUpdate -> updateCount++
+
+        marker1 = layer1.markRange([[0, 2], [0, 4]])
+        marker2 = layer1.markRange([[0, 6], [0, 8]])
+
+        waitsFor -> updateCount is 1
+
+        runs ->
+          marker1.setRange([[1, 2], [3, 4]])
+          marker2.setRange([[4, 5], [6, 7]])
+
+        waitsFor -> updateCount is 2
+
+        runs ->
+          marker1.destroy()
+          marker2.destroy()
+
+        waitsFor -> updateCount is 3

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -1145,7 +1145,13 @@ describe "Marker", ->
         waitsFor -> updateCount is 2
 
         runs ->
+          buffer.insert([0, 1], "xxx")
+          buffer.insert([0, 1], "yyy")
+
+        waitsFor -> updateCount is 3
+
+        runs ->
           marker1.destroy()
           marker2.destroy()
 
-        waitsFor -> updateCount is 3
+        waitsFor -> updateCount is 4

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -1101,6 +1101,23 @@ describe "Marker", ->
       expect(layer1Marker.getRange()).toEqual [[0, 4], [0, 7]]
       expect(layer2Marker.getRange()).toEqual [[0, 7], [0, 10]]
 
+    it "does not emit marker events on the TextBuffer for non-default layers", ->
+      createEventCount = updateEventCount = 0
+      buffer.onDidCreateMarker -> createEventCount++
+      buffer.onDidUpdateMarkers -> updateEventCount++
+
+      marker1 = buffer.markRange([[0, 1], [0, 2]])
+      marker1.setRange([[0, 1], [0, 3]])
+
+      expect(createEventCount).toBe 1
+      expect(updateEventCount).toBe 2
+
+      marker2 = layer1.markRange([[0, 1], [0, 2]])
+      marker2.setRange([[0, 1], [0, 3]])
+
+      expect(createEventCount).toBe 1
+      expect(updateEventCount).toBe 2
+
     describe "::findMarkers(params)", ->
       it "does not find markers from other layers", ->
         defaultMarker = buffer.markRange([[0, 3], [0, 6]])

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -811,9 +811,9 @@ describe "TextBuffer", ->
       expect(buffer.positionForCharacterIndex(20)).toEqual [3, 5]
 
   describe "serialization", ->
-    expectSameMarkers = (buffer1, buffer2) ->
-      markers1 = buffer1.getMarkers().sort (a, b) -> a.compare(b)
-      markers2 = buffer2.getMarkers().sort (a, b) -> a.compare(b)
+    expectSameMarkers = (left, right) ->
+      markers1 = left.getMarkers().sort (a, b) -> a.compare(b)
+      markers2 = right.getMarkers().sort (a, b) -> a.compare(b)
       expect(markers1.length).toBe markers2.length
       for marker1, i in markers1
         expect(marker1).toEqual(markers2[i])
@@ -873,6 +873,25 @@ describe "TextBuffer", ->
       # Doesn't try to reload the buffer since it has no file.
       waits(50)
       runs -> expect(bufferB.getText()).toBe "hello\nworld\r\nhow are you doing?"
+
+    it "serializes / deserializes the buffer's custom marker layers", ->
+      bufferA = new TextBuffer("abcdefghijklmnopqrstuvwxyz")
+
+      layer1A = bufferA.addMarkerLayer()
+      layer2A = bufferA.addMarkerLayer()
+
+      layer1A.markRange([[0, 1], [0, 2]])
+      layer1A.markRange([[0, 3], [0, 4]])
+
+      layer2A.markRange([[0, 5], [0, 6]])
+      layer2A.markRange([[0, 7], [0, 8]])
+
+      bufferB = TextBuffer.deserialize(JSON.parse(JSON.stringify(bufferA.serialize())))
+      layer1B = bufferB.getMarkerLayer(layer1A.id)
+      layer2B = bufferB.getMarkerLayer(layer2A.id)
+
+      expectSameMarkers(layer1A, layer1B)
+      expectSameMarkers(layer2A, layer2B)
 
     it "doesn't serialize markers with the 'persistent' option set to false", ->
       bufferA = new TextBuffer(text: "hello\nworld\r\nhow are you doing?")

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -185,7 +185,7 @@ class MarkerLayer
         else
           marker.emitChangeEvent(marker.getRange(), true, false)
 
-    @delegate.markersUpdated()
+    @delegate.markersUpdated(this)
     return
 
   createSnapshot: (emitChangeEvents=false) ->
@@ -197,7 +197,7 @@ class MarkerLayer
           result[id] = marker.getSnapshot(ranges[id], false)
         if emitChangeEvents
           marker.emitChangeEvent(ranges[id], true, false)
-    @delegate.markersUpdated() if emitChangeEvents
+    @delegate.markersUpdated(this) if emitChangeEvents
     result
 
   serialize: ->
@@ -223,14 +223,14 @@ class MarkerLayer
   ###
 
   markerUpdated: ->
-    @delegate.markersUpdated()
+    @delegate.markersUpdated(this)
     @scheduleUpdateEvent()
 
   destroyMarker: (id) ->
     delete @markersById[id]
     @historiedMarkers.delete(id)
     @index.delete(id)
-    @delegate.markersUpdated()
+    @delegate.markersUpdated(this)
     @scheduleUpdateEvent()
 
   getMarkerRange: (id) ->
@@ -255,8 +255,8 @@ class MarkerLayer
   createMarker: (range, params) ->
     id = @id + '-' + @nextMarkerId++
     marker = @addMarker(id, range, params)
-    @delegate.markerCreated(marker)
-    @delegate.markersUpdated()
+    @delegate.markerCreated(this, marker)
+    @delegate.markersUpdated(this)
     @scheduleUpdateEvent()
     marker
 

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -8,9 +8,9 @@ MarkerIndex = require "./marker-index"
 SerializationVersion = 2
 
 module.exports =
-class MarkerStore
+class MarkerLayer
   @deserialize: (delegate, state) ->
-    store = new MarkerStore(delegate, 0)
+    store = new MarkerLayer(delegate, 0)
     store.deserialize(state)
     store
 

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -162,6 +162,7 @@ class MarkerLayer
       marker.valid = false if invalid
 
     @index.splice(start, oldExtent, newExtent)
+    @scheduleUpdateEvent()
 
   restoreFromSnapshot: (snapshots) ->
     return unless snapshots?

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -45,6 +45,11 @@ class MarkerLayer
   destroy: ->
     @destroyed = true
     @delegate.markerLayerDestroyed(this)
+    @emitter.emit 'did-destroy'
+    @emitter.dispose()
+
+  onDidDestroy: (callback) ->
+    @emitter.on 'did-destroy', callback
 
   isAlive: ->
     not @destroyed

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -28,6 +28,10 @@ class MarkerLayer
       result[id].range = Range.deserialize(markerSnapshot.range)
     result
 
+  ###
+  Section: Lifecycle
+  ###
+
   constructor: (@delegate, @id) ->
     @index = new MarkerIndex
     @markersById = {}
@@ -35,6 +39,7 @@ class MarkerLayer
     @nextMarkerId = 0
     @destroyed = false
 
+  # Public: Remove the {MarkerLayer} from the {TextBuffer}
   destroy: ->
     @destroyed = true
     @delegate.markerLayerDestroyed(this)
@@ -46,18 +51,28 @@ class MarkerLayer
     @destroyed
 
   ###
-  Section: TextBuffer API
+  Section: Public interface
   ###
 
+  # Public: Get an existing marker by its id.
   getMarker: (id) ->
     @markersById[id]
 
+  # Public: Get all existing markers on the buffer.
+  #
+  # Returns an {Array} of {Marker}s.
   getMarkers: ->
     marker for id, marker of @markersById
 
+  # Public: Get the number of markers in the buffer.
+  #
+  # Returns a {Number}.
   getMarkerCount: ->
     Object.keys(@markersById).length
 
+  # Public: Find markers conforming to the given parameters.
+  #
+  # See the documentation for {TextBuffer::findMarkers}.
   findMarkers: (params) ->
     markerIds = null
 
@@ -99,13 +114,23 @@ class MarkerLayer
       result.push(marker) if marker.matchesParams(params)
     result.sort (a, b) -> a.compare(b)
 
+  # Public: Create a marker with the given range.
+  #
+  # See the documentation for {TextBuffer::markRange}
   markRange: (range, options={}) ->
     @createMarker(@delegate.clipRange(range), Marker.extractParams(options))
 
+  # Public: Create a marker with the given position and no tail.
+  #
+  # See the documentation for {TextBuffer::markPosition}
   markPosition: (position, options={}) ->
     options.tailed ?= false
     position = @delegate.clipPosition(position)
     @markRange(new Range(position, position), options)
+
+  ###
+  Section: Private - TextBuffer interface
+  ###
 
   splice: (start, oldExtent, newExtent) ->
     end = start.traverse(oldExtent)
@@ -189,7 +214,7 @@ class MarkerLayer
     return
 
   ###
-  Section: Marker interface
+  Section: Private - Marker interface
   ###
 
   markerUpdated: ->
@@ -228,7 +253,7 @@ class MarkerLayer
     marker
 
   ###
-  Section: Private
+  Section: Internal
   ###
 
   addMarker: (id, range, params) ->

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -43,7 +43,7 @@ class Marker
 
   @delegatesMethods 'containsPoint', 'containsRange', 'intersectsRow', toMethod: 'getRange'
 
-  constructor: (@id, @store, range, params) ->
+  constructor: (@id, @layer, range, params) ->
     {@tailed, @reversed, @valid, @invalidate, @persistent, @properties, @maintainHistory} = params
     @emitter = new Emitter
     @tailed ?= true
@@ -56,7 +56,7 @@ class Marker
     @hasChangeObservers = false
     @rangeWhenDestroyed = null
     Object.freeze(@properties)
-    @store.setMarkerHasTail(@id, @tailed)
+    @layer.setMarkerHasTail(@id, @tailed)
 
   ###
   Section: Event Subscription
@@ -96,7 +96,7 @@ class Marker
 
   # Public: Returns the current {Range} of the marker. The range is immutable.
   getRange: ->
-    @rangeWhenDestroyed ? @store.getMarkerRange(@id)
+    @rangeWhenDestroyed ? @layer.getMarkerRange(@id)
 
   # Public: Sets the range of the marker.
   #
@@ -182,12 +182,12 @@ class Marker
   # Public: Returns a {Point} representing the start position of the marker,
   # which could be the head or tail position, depending on its orientation.
   getStartPosition: ->
-    @rangeWhenDestroyed?.start ? @store.getMarkerStartPosition(@id)
+    @rangeWhenDestroyed?.start ? @layer.getMarkerStartPosition(@id)
 
   # Public: Returns a {Point} representing the end position of the marker,
   # which could be the head or tail position, depending on its orientation.
   getEndPosition: ->
-    @rangeWhenDestroyed?.end ? @store.getMarkerEndPosition(@id)
+    @rangeWhenDestroyed?.end ? @layer.getMarkerEndPosition(@id)
 
   # Public: Removes the marker's tail. After calling the marker's head position
   # will be reported as its current tail position until the tail is planted
@@ -273,7 +273,7 @@ class Marker
   copy: (options={}) ->
     snapshot = @getSnapshot(null)
     options = Marker.extractParams(options)
-    @store.createMarker(@getRange(), extend(
+    @layer.createMarker(@getRange(), extend(
       {}
       snapshot,
       options,
@@ -284,7 +284,7 @@ class Marker
   # destroyed, a marker cannot be restored by undo/redo operations.
   destroy: ->
     @rangeWhenDestroyed = @getRange()
-    @store.destroyMarker(@id)
+    @layer.destroyMarker(@id)
     @emitter.emit 'did-destroy'
     @emit 'destroyed' if Grim.includeDeprecatedAPIs
 
@@ -335,7 +335,7 @@ class Marker
     updated = propertiesChanged = false
 
     if range? and not range.isEqual(oldRange)
-      @store.setMarkerRange(@id, range)
+      @layer.setMarkerRange(@id, range)
       updated = true
 
     if reversed? and reversed isnt @reversed
@@ -344,7 +344,7 @@ class Marker
 
     if tailed? and tailed isnt @tailed
       @tailed = tailed
-      @store.setMarkerHasTail(@id, @tailed)
+      @layer.setMarkerHasTail(@id, @tailed)
       updated = true
 
     if valid? and valid isnt @valid
@@ -357,7 +357,7 @@ class Marker
       updated = true
 
     @emitChangeEvent(range ? oldRange, textChanged, propertiesChanged)
-    @store.markerUpdated() if updated and not textChanged
+    @layer.markerUpdated() if updated and not textChanged
     updated
 
   getSnapshot: (range) ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -59,7 +59,7 @@ class TransactionAbortedError extends Error
 # annotate logical regions in the text.
 module.exports =
 class TextBuffer
-  @version: 2
+  @version: 3
   @Point: Point
   @Range: Range
   @Patch: Patch

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1500,13 +1500,15 @@ class TextBuffer
       @customMarkerLayers.splice(index, 1)
     return
 
-  markerCreated: (marker) ->
-    @emitter.emit 'did-create-marker', marker
-    @emit 'marker-created', marker if Grim.includeDeprecatedAPIs
+  markerCreated: (layer, marker) ->
+    if layer is @defaultMarkerLayer
+      @emitter.emit 'did-create-marker', marker
+      @emit 'marker-created', marker if Grim.includeDeprecatedAPIs
 
-  markersUpdated: ->
-    @emitter.emit 'did-update-markers'
-    @emit 'markers-updated' if Grim.includeDeprecatedAPIs
+  markersUpdated: (layer) ->
+    if layer is @defaultMarkerLayer
+      @emitter.emit 'did-update-markers'
+      @emit 'markers-updated' if Grim.includeDeprecatedAPIs
 
 if Grim.includeDeprecatedAPIs
   EmitterMixin = require('emissary').Emitter

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -798,6 +798,9 @@ class TextBuffer
         return customMarkerLayer
     undefined
 
+  getDefaultMarkerLayer: ->
+    @defaultMarkerLayer
+
   # Public: Create a marker with the given range. This marker will maintain
   # its logical location as the buffer is changed, so if you mark a particular
   # word, the marker will remain over that word even if the word's location in

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -789,6 +789,12 @@ class TextBuffer
     @customMarkerLayers.push(layer)
     layer
 
+  getMarkerLayer: (id) ->
+    for customMarkerLayer in @customMarkerLayers
+      if customMarkerLayer.id is id
+        return customMarkerLayer
+    undefined
+
   # Public: Create a marker with the given range. This marker will maintain
   # its logical location as the buffer is changed, so if you mark a particular
   # word, the marker will remain over that word even if the word's location in

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -79,6 +79,7 @@ class TextBuffer
   backwardsScanChunkSize: 8000
   defaultMaxUndoEntries: 10000
   changeCount: 0
+  nextMarkerStoreId: 0
 
   ###
   Section: Construction
@@ -100,7 +101,10 @@ class TextBuffer
     @setTextInRange([[0, 0], [0, 0]], text ? params?.text ? '', normalizeLineEndings: false)
     maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
     @history = params?.history ? new History(this, maxUndoEntries)
-    @markerStore = params?.markerStore ? new MarkerStore(this)
+    @nextMarkerLayerId = params?.nextMarkerStoreId ? 0
+    @defaultMarkerLayer = params?.defaultMarkerLayer ? new MarkerStore(this, String(@nextMarkerLayerId++))
+    @customMarkerLayers = params?.customMarkerLayers ? []
+
     @setEncoding(params?.encoding)
     @setPreferredLineEnding(params?.preferredLineEnding)
 
@@ -113,7 +117,7 @@ class TextBuffer
 
   # Called by {Serializable} mixin during deserialization.
   deserializeParams: (params) ->
-    params.markerStore = MarkerStore.deserialize(this, params.markerStore)
+    params.defaultMarkerLayer = MarkerStore.deserialize(this, params.defaultMarkerLayer)
     params.history = History.deserialize(this, params.history)
     params.load = true if params.filePath
     params
@@ -121,7 +125,8 @@ class TextBuffer
   # Called by {Serializable} mixin during serialization.
   serializeParams: ->
     text: @getText()
-    markerStore: @markerStore.serialize()
+    defaultMarkerLayer: @defaultMarkerLayer.serialize()
+    nextMarkerLayerId: @nextMarkerLayerId
     history: @history.serialize()
     encoding: @getEncoding()
     filePath: @getPath()
@@ -267,7 +272,6 @@ class TextBuffer
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidSave: (callback) ->
     @emitter.on 'did-save', callback
-
 
   # Public: Invoke the given callback after the file backing the buffer is
   # deleted.
@@ -709,7 +713,13 @@ class TextBuffer
       {rows: 1, characters: line.length + lineEndings[index].length}
     @offsetIndex.spliceArray('rows', startRow, rowCount, offsets)
 
-    @markerStore?.splice(oldRange.start, oldRange.getExtent(), newRange.getExtent())
+    if @defaultMarkerLayer?
+      oldExtent = oldRange.getExtent()
+      newExtent = newRange.getExtent()
+      @defaultMarkerLayer.splice(oldRange.start, oldExtent, newExtent)
+      for customMarkerLayer in @customMarkerLayers
+        customMarkerLayer.splice(oldRange.start, oldExtent, newExtent)
+
     @history?.pushChange(change) unless skipUndo
 
     @conflict = false if @conflict and !@isModified()
@@ -774,6 +784,11 @@ class TextBuffer
   Section: Markers
   ###
 
+  addMarkerLayer: ->
+    layer = new MarkerStore(this, String(@nextMarkerLayerId++))
+    @customMarkerLayers.push(layer)
+    layer
+
   # Public: Create a marker with the given range. This marker will maintain
   # its logical location as the buffer is changed, so if you mark a particular
   # word, the marker will remain over that word even if the word's location in
@@ -806,7 +821,7 @@ class TextBuffer
   #       start or start at the marker's end. This is the most fragile strategy.
   #
   # Returns a {Marker}.
-  markRange: (range, properties) -> @markerStore.markRange(@clipRange(range), properties)
+  markRange: (range, properties) -> @defaultMarkerLayer.markRange(range, properties)
 
   # Public: Create a marker at the given position with no tail.
   #
@@ -814,19 +829,19 @@ class TextBuffer
   # * `properties` This is the same as the `properties` parameter in {::markRange}
   #
   # Returns a {Marker}.
-  markPosition: (position, properties) -> @markerStore.markPosition(@clipPosition(position), properties)
+  markPosition: (position, properties) -> @defaultMarkerLayer.markPosition(position, properties)
 
   # Public: Get all existing markers on the buffer.
   #
   # Returns an {Array} of {Marker}s.
-  getMarkers: -> @markerStore.getMarkers()
+  getMarkers: -> @defaultMarkerLayer.getMarkers()
 
   # Public: Get an existing marker by its id.
   #
   # * `id` {Number} id of the marker to retrieve
   #
   # Returns a {Marker}.
-  getMarker: (id) -> @markerStore.getMarker(id)
+  getMarker: (id) -> @defaultMarkerLayer.getMarker(id)
 
   # Public: Find markers conforming to the given parameters.
   #
@@ -846,12 +861,12 @@ class TextBuffer
   #   * `intersectsRow` Only include markers that intersect the given row {Number}.
   #
   # Returns an {Array} of {Marker}s.
-  findMarkers: (params) -> @markerStore.findMarkers(params)
+  findMarkers: (params) -> @defaultMarkerLayer.findMarkers(params)
 
   # Public: Get the number of markers in the buffer.
   #
   # Returns a {Number}.
-  getMarkerCount: -> @markerStore.getMarkerCount()
+  getMarkerCount: -> @defaultMarkerLayer.getMarkerCount()
 
   destroyMarker: (id) ->
     @getMarker(id)?.destroy()
@@ -864,7 +879,7 @@ class TextBuffer
   undo: ->
     if pop = @history.popUndoStack()
       @applyChange(change, true) for change in pop.changes
-      @markerStore.restoreFromSnapshot(pop.snapshot)
+      @defaultMarkerLayer.restoreFromSnapshot(pop.snapshot)
       true
     else
       false
@@ -873,7 +888,7 @@ class TextBuffer
   redo: ->
     if pop = @history.popRedoStack()
       @applyChange(change, true) for change in pop.changes
-      @markerStore.restoreFromSnapshot(pop.snapshot)
+      @defaultMarkerLayer.restoreFromSnapshot(pop.snapshot)
       true
     else
       false
@@ -896,7 +911,7 @@ class TextBuffer
       fn = groupingInterval
       groupingInterval = 0
 
-    checkpointBefore = @history.createCheckpoint(@markerStore.createSnapshot(false), true)
+    checkpointBefore = @history.createCheckpoint(@defaultMarkerLayer.createSnapshot(false), true)
 
     try
       @transactCallDepth++
@@ -908,7 +923,7 @@ class TextBuffer
     finally
       @transactCallDepth--
 
-    @history.groupChangesSinceCheckpoint(checkpointBefore, @markerStore.createSnapshot(true), true)
+    @history.groupChangesSinceCheckpoint(checkpointBefore, @defaultMarkerLayer.createSnapshot(true), true)
     @history.applyGroupingInterval(groupingInterval)
 
     result
@@ -924,7 +939,7 @@ class TextBuffer
   #
   # Returns a checkpoint value.
   createCheckpoint: ->
-    @history.createCheckpoint(@markerStore.createSnapshot(), false)
+    @history.createCheckpoint(@defaultMarkerLayer.createSnapshot(), false)
 
   # Public: Revert the buffer to the state it was in when the given
   # checkpoint was created.
@@ -938,7 +953,7 @@ class TextBuffer
   revertToCheckpoint: (checkpoint) ->
     if truncated = @history.truncateUndoStack(checkpoint)
       @applyChange(change, true) for change in truncated.changes
-      @markerStore.restoreFromSnapshot(truncated.snapshot)
+      @defaultMarkerLayer.restoreFromSnapshot(truncated.snapshot)
       @emitter.emit 'did-update-markers'
       @emit 'markers-updated' if Grim.includeDeprecatedAPIs
       true
@@ -953,7 +968,7 @@ class TextBuffer
   #
   # Returns a {Boolean} indicating whether the operation succeeded.
   groupChangesSinceCheckpoint: (checkpoint) ->
-    @history.groupChangesSinceCheckpoint(checkpoint, @markerStore.createSnapshot(false), false)
+    @history.groupChangesSinceCheckpoint(checkpoint, @defaultMarkerLayer.createSnapshot(false), false)
 
   ###
   Section: Search And Replace
@@ -1469,6 +1484,12 @@ class TextBuffer
   ###
   Section: Private MarkerStore Delegate Methods
   ###
+
+  markerLayerDestroyed: (markerLayer) ->
+    index = @customMarkerLayers.indexOf(markerLayer)
+    if index isnt -1
+      @customMarkerLayers.splice(index, 1)
+    return
 
   markerCreated: (marker) ->
     @emitter.emit 'did-create-marker', marker

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -118,6 +118,8 @@ class TextBuffer
   # Called by {Serializable} mixin during deserialization.
   deserializeParams: (params) ->
     params.defaultMarkerLayer = MarkerStore.deserialize(this, params.defaultMarkerLayer)
+    params.customMarkerLayers = for layerParams in params.customMarkerLayers
+      MarkerStore.deserialize(this, layerParams)
     params.history = History.deserialize(this, params.history)
     params.load = true if params.filePath
     params
@@ -126,6 +128,7 @@ class TextBuffer
   serializeParams: ->
     text: @getText()
     defaultMarkerLayer: @defaultMarkerLayer.serialize()
+    customMarkerLayers: @customMarkerLayers.map (layer) -> layer.serialize()
     nextMarkerLayerId: @nextMarkerLayerId
     history: @history.serialize()
     encoding: @getEncoding()


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/9208

* [x] Add the ability for a buffer to have multiple marker layers
* [x] Serialize and deserialize custom marker layers
* [x] Rename `MarkerStore` -> `MarkerLayer`
* [x] Document public `MarkerLayer` methods