### PR TITLE
Remove unused local variables.

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -665,8 +665,6 @@ class TextBuffer
     startRow = oldRange.start.row
     endRow = oldRange.end.row
     rowCount = endRow - startRow + 1
-    oldExtent = oldRange.getExtent()
-    newExtent = newRange.getExtent()
 
     # Determine how to normalize the line endings of inserted text if enabled
     if normalizeLineEndings


### PR DESCRIPTION
oldExtent and newExtent are not used in TextBuffer.applyChange method.