### PR TITLE
Use native MarkerIndex implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",
-    "marker-index": "^2.1.1",
+    "marker-index": "^3.0.2",
     "pathwatcher": "^6.2.3",
     "serializable": "^1.0.3",
     "span-skip-list": "~0.2.0",

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -46,7 +46,6 @@ class MarkerLayer
     @index = new MarkerIndex
     @markersById = {}
     @markersIdsWithChangeSubscriptions = new Set
-    @nextMarkerId = 0
     @destroyed = false
     @emitCreateMarkerEvents = false
 
@@ -251,12 +250,11 @@ class MarkerLayer
     for id in Object.keys(@markersById)
       marker = @markersById[id]
       markersById[id] = marker.getSnapshot(Range.fromObject(ranges[id]), false) if marker.persistent
-    {@nextMarkerId, @id, @maintainHistory, markersById, version: SerializationVersion}
+    {@id, @maintainHistory, markersById, version: SerializationVersion}
 
   deserialize: (state) ->
     return unless state.version is SerializationVersion
     @id = state.id
-    @nextMarkerId = state.nextMarkerId
     @maintainHistory = state.maintainHistory
     for id, markerState of state.markersById
       range = Range.fromObject(markerState.range)
@@ -300,7 +298,7 @@ class MarkerLayer
     @index.setExclusive(id, not hasTail)
 
   createMarker: (range, params) ->
-    id = @id + '-' + @nextMarkerId++
+    id = @delegate.getNextMarkerId()
     marker = @addMarker(id, range, params)
     @delegate.markerCreated(this, marker)
     @delegate.markersUpdated(this)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -58,7 +58,7 @@ class TransactionAbortedError extends Error
 # annotate logical regions in the text.
 module.exports =
 class TextBuffer
-  @version: 4
+  @version: 5
   @Point: Point
   @Range: Range
   @Patch: Patch
@@ -104,6 +104,7 @@ class TextBuffer
     @defaultMarkerLayer = params?.defaultMarkerLayer ? new MarkerLayer(this, String(@nextMarkerLayerId++))
     @markerLayers = params?.markerLayers ? {}
     @markerLayers[@defaultMarkerLayer.id] = @defaultMarkerLayer
+    @nextMarkerId = params?.nextMarkerId ? 1
 
     @setEncoding(params?.encoding)
     @setPreferredLineEnding(params?.preferredLineEnding)
@@ -141,6 +142,7 @@ class TextBuffer
     filePath: @getPath()
     digestWhenLastPersisted: @file?.getDigestSync()
     preferredLineEnding: @preferredLineEnding
+    nextMarkerId: @nextMarkerId
 
   ###
   Section: Event Subscription
@@ -1531,3 +1533,5 @@ class TextBuffer
   markersUpdated: (layer) ->
     if layer is @defaultMarkerLayer
       @emitter.emit 'did-update-markers'
+
+  getNextMarkerId: -> @nextMarkerId++


### PR DESCRIPTION
Having implemented a simpler binary-tree algorithm for the `MarkerIndex`, I wanted to see what we could gain by [dropping it to C++](https://github.com/atom/marker-index/pull/2). Tests of both implementations vary pretty dramatically between runs, but I'm seeing roughly the following when searching for `e` in jQuery after 6 runs of each version:

| Implementation | Typical Time | Worst Time | Typical Total GC Time
| ------ | ----------- | ---- | ---- |
| native | 900ms | 1070ms | 90ms
| JS | 1200ms | 1500ms | 180ms

So the JS version is definitely more variable, slower overall, and puts more pressure on the garbage collector. A 300-600ms improvement based on my tests. Keep in mind there's a bunch of other stuff going on in this code path, but I wanted to measure a real-world use case for this data structure anyway.