### PR TITLE
Assign a unique id to new TextBuffer instances

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -50,6 +50,12 @@ describe "TextBuffer", ->
       expect(buffer.lineForRow(1)).toBe ''
       expect(buffer.lineEndingForRow(1)).toBe ''
 
+    it "automatically assigns a unique identifier to new buffers", ->
+      bufferIds = [0..16].map(-> new TextBuffer().getId())
+      uniqueBufferIds = new Set(bufferIds)
+
+      expect(uniqueBufferIds.size).toBe(bufferIds.length)
+
     describe "when a file path is given", ->
       [filePath] = []
 
@@ -904,6 +910,12 @@ describe "TextBuffer", ->
       bufferB = TextBuffer.deserialize(bufferA.serialize())
       expect(bufferB.getMarker(marker1A.id)).toBeUndefined()
       expect(bufferB.getMarker(marker2A.id)).toBeDefined()
+
+    it "serializes / deserializes the buffer's unique identifier", ->
+      bufferA = new TextBuffer()
+      bufferB = TextBuffer.deserialize(JSON.parse(JSON.stringify(bufferA.serialize())))
+
+      expect(bufferB.getId()).toEqual(bufferA.getId())
 
     describe "when the buffer has a path", ->
       [filePath, buffer2] = []

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -6,6 +6,7 @@ diff = require 'atom-diff'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
+crypto = require 'crypto'
 
 Point = require './point'
 Range = require './range'
@@ -94,6 +95,7 @@ class TextBuffer
     text = params if typeof params is 'string'
 
     @emitter = new Emitter
+    @id = params?.id ? crypto.randomBytes(16).toString('hex')
     @lines = ['']
     @lineEndings = ['']
     @offsetIndex = new SpanSkipList('rows', 'characters')
@@ -116,6 +118,10 @@ class TextBuffer
     @setPath(params.filePath) if params?.filePath
     @load() if params?.load
 
+  # Returns a {String} representing a unique identifier for this {TextBuffer}.
+  getId: ->
+    @id
+
   # Called by {Serializable} mixin during deserialization.
   deserializeParams: (params) ->
     markerLayers = {}
@@ -133,6 +139,7 @@ class TextBuffer
     for id, layer of @markerLayers
       markerLayers[id] = layer.serialize()
 
+    id: @getId()
     text: @getText()
     defaultMarkerLayerId: @defaultMarkerLayer.id
     markerLayers: markerLayers


### PR DESCRIPTION
So that we can have a unique identifier to deserialize buffers that do not have a path (i.e. untitled buffers).

/cc: @atom/feedback @nathansobo 