### PR TITLE
Fix ::isModified for unsaved buffers

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1404,6 +1404,15 @@ describe "TextBuffer", ->
         buffer.setText('\n')
         expect(buffer.isModified()).toBeTruthy()
 
+    it "returns true when constructing a non-empty buffer with no path and not loading it", ->
+      buffer.destroy()
+      buffer = new TextBuffer(text: "hello world")
+      expect(buffer.isModified()).toBe(true)
+      buffer.append("something")
+      expect(buffer.isModified()).toBe(true)
+      buffer.setText("")
+      expect(buffer.isModified()).toBe(false)
+
     it "returns false until the buffer is fully loaded", ->
       buffer.destroy()
       buffer = new TextBuffer({filePath, load: true})

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1391,6 +1391,11 @@ describe "TextBuffer", ->
       runs ->
         expect(buffer.isModified()).toBeFalsy()
 
+    it "returns false when constructing an empty buffer with no path and loading it", ->
+      buffer.destroy()
+      buffer = new TextBuffer()
+      expect(buffer.isModified()).toBeFalsy()
+
     it "returns true for a non-empty buffer with no path", ->
       buffer.destroy()
       buffer = new TextBuffer({load: true})

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1383,40 +1383,19 @@ describe "TextBuffer", ->
 
     it "returns false for an empty buffer with no path", ->
       buffer.destroy()
-      buffer = new TextBuffer({load: true})
-
-      waitsFor ->
-        buffer.loaded
-
-      runs ->
-        expect(buffer.isModified()).toBeFalsy()
-
-    it "returns false when constructing an empty buffer with no path and not loading it", ->
-      buffer.destroy()
       buffer = new TextBuffer()
       expect(buffer.isModified()).toBeFalsy()
+      buffer.append('hello')
+      expect(buffer.isModified()).toBeTruthy()
 
     it "returns true for a non-empty buffer with no path", ->
       buffer.destroy()
-      buffer = new TextBuffer({load: true})
-
-      waitsFor ->
-        buffer.loaded
-
-      runs ->
-        buffer.setText('a')
-        expect(buffer.isModified()).toBeTruthy()
-        buffer.setText('\n')
-        expect(buffer.isModified()).toBeTruthy()
-
-    it "returns true when constructing a non-empty buffer with no path and not loading it", ->
-      buffer.destroy()
-      buffer = new TextBuffer(text: "hello world")
-      expect(buffer.isModified()).toBe(true)
-      buffer.append("something")
-      expect(buffer.isModified()).toBe(true)
-      buffer.setText("")
-      expect(buffer.isModified()).toBe(false)
+      buffer = new TextBuffer({text: 'something'})
+      expect(buffer.isModified()).toBeTruthy()
+      buffer.append('a')
+      expect(buffer.isModified()).toBeTruthy()
+      buffer.setText('')
+      expect(buffer.isModified()).toBeFalsy()
 
     it "returns false until the buffer is fully loaded", ->
       buffer.destroy()

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1391,7 +1391,7 @@ describe "TextBuffer", ->
       runs ->
         expect(buffer.isModified()).toBeFalsy()
 
-    it "returns false when constructing an empty buffer with no path and loading it", ->
+    it "returns false when constructing an empty buffer with no path and not loading it", ->
       buffer.destroy()
       buffer = new TextBuffer()
       expect(buffer.isModified()).toBeFalsy()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -356,8 +356,9 @@ class TextBuffer
   #
   # Returns a {Boolean}.
   isModified: ->
-    return false unless @loaded
     if @file
+      return false unless @loaded
+
       if @file.existsSync()
         @getText() != @cachedDiskContents
       else


### PR DESCRIPTION
While trying to break https://github.com/atom/atom/pull/9968, I noticed that after instantiating a `TextBuffer` without passing `load: true` when the buffer hadn't a file path (i.e. which is what happens when deserializing an untitled editor) caused `TextBuffer::isModified` to alter its behavior, thereby always returning `false`.

I think there was a misplaced guard clause in the `::isModified` method and I moved it, changing two existing specs to clarify this behavior, which now seems consistent also with the documentation:

```
# Public: Determine if the in-memory contents of the buffer differ from its
# contents on disk.
#
# If the buffer is unsaved, always returns `true` unless the buffer is empty.
#
# Returns a {Boolean}.
```

/cc: @nathansobo @maxbrunsfeld for :eyes: 