### PR TITLE
Make TextBuffer::setEncoding faster

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -404,9 +404,7 @@ class TextBuffer
       @emitter.emit 'did-change-encoding', encoding
 
       unless @isModified()
-        @updateCachedDiskContents true, =>
-          @reload()
-          @clearUndoStack()
+        @updateCachedDiskContents true, => @reload(true)
     else
       @emitter.emit 'did-change-encoding', encoding
 


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/9979

Before this PR, when setting the encoding for a buffer, we reloaded the whole file and cleared the undo stack afterwards. This can be particularly slow as the file gets bigger, because calling `::reload` will actually change the buffer through a diff in order to keep track of the history. 

![screen shot 2015-12-08 at 16 30 07](https://cloud.githubusercontent.com/assets/482957/11659539/1f7b36ea-9dc9-11e5-8fdb-896505bc5e2f.png)

However, since we clear the undo history right after reloading the file, we can pass `true` to `::reload` in order to avoid computing the diff altogether. Specs-wise nothing should change, as the behavior should be 100% backwards compatible.

/cc: @nathansobo @maxbrunsfeld @atom/feedback 