### PR TITLE
Fix exception when snapshot references non-existent marker layers

### DIFF
--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -943,6 +943,14 @@ describe "Marker", ->
         buffer.redo()
         expect(marker.getRange()).toEqual [[0, 8], [0, 12]]
 
+      it "ignores snapshot references to marker layers that no longer exist", ->
+        layer3.markRange([[0, 6], [0, 9]])
+        buffer.append("stuff")
+        layer3.destroy()
+
+        # Should not throw an exception
+        buffer.undo()
+
     describe "::findMarkers(params)", ->
       it "does not find markers from other layers", ->
         defaultMarker = buffer.markRange([[0, 3], [0, 6]])

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1453,7 +1453,7 @@ class TextBuffer
 
   restoreFromMarkerSnapshot: (snapshot) ->
     for markerLayerId, layerSnapshot of snapshot
-      @markerLayers[markerLayerId].restoreFromSnapshot(layerSnapshot)
+      @markerLayers[markerLayerId]?.restoreFromSnapshot(layerSnapshot)
 
   emitMarkerChangeEvents: (snapshot) ->
     for markerLayerId, markerLayer of @markerLayers


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/9918
Fixes https://github.com/atom/vim-mode/issues/919