### PR TITLE
Provide consolidated changes to ::onDidStopChanging callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "delegato": "^1.0.0",
     "atom-diff": "^2",
-    "atom-patch": "0.0.2",
+    "atom-patch": "0.0.3",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "delegato": "^1.0.0",
     "atom-diff": "^2",
+    "atom-patch": "0.0.2",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2336,15 +2336,20 @@ describe "TextBuffer", ->
     it "notifies observers after a delay passes following changes", ->
       delay = buffer.stoppedChangingDelay
       didStopChangingCallback = jasmine.createSpy("didStopChangingCallback")
-      buffer.onDidStopChanging didStopChangingCallback
 
-      buffer.insert([0, 0], 'a')
-      expect(didStopChangingCallback).not.toHaveBeenCalled()
+      waits delay
+
+      runs ->
+        buffer.onDidStopChanging didStopChangingCallback
+
+        buffer.insert([0, 0], 'a')
+        expect(didStopChangingCallback).not.toHaveBeenCalled()
 
       waits delay / 2
 
       runs ->
         buffer.insert([0, 0], 'b')
+        buffer.insert([1, 0], 'c')
         expect(didStopChangingCallback).not.toHaveBeenCalled()
 
       waits delay / 2
@@ -2356,6 +2361,20 @@ describe "TextBuffer", ->
 
       runs ->
         expect(didStopChangingCallback).toHaveBeenCalled()
+        expect(didStopChangingCallback.mostRecentCall.args[0]).toEqual [
+          {
+            start: {row: 0, column: 0},
+            replacedExtent: {row: 0, column: 0},
+            replacementExtent: {row: 0, column: 2},
+            replacementText: 'ba'
+          },
+          {
+            start: {row: 1, column: 0},
+            replacedExtent: {row: 0, column: 0},
+            replacementExtent: {row: 0, column: 1},
+            replacementText: 'c'
+          }
+        ]
 
         didStopChangingCallback.reset()
         buffer.undo()

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2364,15 +2364,15 @@ describe "TextBuffer", ->
         expect(didStopChangingCallback.mostRecentCall.args[0]).toEqual [
           {
             start: {row: 0, column: 0},
-            replacedExtent: {row: 0, column: 0},
-            replacementExtent: {row: 0, column: 2},
-            replacementText: 'ba'
+            oldExtent: {row: 0, column: 0},
+            newExtent: {row: 0, column: 2},
+            newText: 'ba'
           },
           {
             start: {row: 1, column: 0},
-            replacedExtent: {row: 0, column: 0},
-            replacementExtent: {row: 0, column: 1},
-            replacementText: 'c'
+            oldExtent: {row: 0, column: 0},
+            newExtent: {row: 0, column: 1},
+            newText: 'c'
           }
         ]
 


### PR DESCRIPTION
I think we can use this in the `spell-check` package to avoid re-checking the entire file every time the user stops typing.

/cc @nathansobo were you going to rename `replacedExtent` to `oldExtent` and `replacementExtent` to `newExtent` inside of `atom-patch`? If so, we should probably do that before merging this.

/cc @as-cii maybe this could be useful in the `autocomplete-plus` [SymbolProvider](https://github.com/atom/autocomplete-plus/blob/db35d7a9ae16d2a86f605e63f02140e22b364b92/lib/symbol-provider.coffee#L55) also.