### PR TITLE
Introduce TextBuffer.prototype.onDidChangeText

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "delegato": "^1.0.0",
     "atom-diff": "^2",
-    "atom-patch": "0.0.4",
+    "atom-patch": "0.0.6",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "delegato": "^1.0.0",
     "atom-diff": "^2",
-    "atom-patch": "0.0.6",
+    "atom-patch": "0.0.8",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2333,22 +2333,19 @@ describe "TextBuffer", ->
       waitsFor ->
         buffer.loaded
 
-    it "notifies observers at the end of each transaction", ->
+    it "notifies observers after a transaction, an undo or a redo", ->
       textChanges = []
-      buffer.onDidChangeText (changes) -> textChanges.push(changes)
+      buffer.onDidChangeText (changes) -> textChanges.push(changes...)
 
       buffer.insert([0, 0], "abc")
       buffer.delete([[0, 0], [0, 1]])
-      expect(textChanges.length).toBe(2)
-      expect(textChanges[0]).toEqual([
+      expect(textChanges).toEqual([
         {
           start: {row: 0, column: 0},
           oldExtent: {row: 0, column: 0},
           newExtent: {row: 0, column: 3},
           newText: "abc"
-        }
-      ])
-      expect(textChanges[1]).toEqual([
+        },
         {
           start: {row: 0, column: 0},
           oldExtent: {row: 0, column: 1},
@@ -2364,8 +2361,41 @@ describe "TextBuffer", ->
         buffer.insert([2, 3], "zw")
         buffer.delete([[2, 3], [2, 4]])
 
-      expect(textChanges.length).toBe(1)
-      expect(textChanges[0]).toEqual([
+      expect(textChanges).toEqual([
+        {
+          start: {row: 1, column: 0},
+          oldExtent: {row: 0, column: 0},
+          newExtent: {row: 0, column: 2},
+          newText: "xy"
+        },
+        {
+          start: {row: 2, column: 3},
+          oldExtent: {row: 0, column: 0},
+          newExtent: {row: 0, column: 1},
+          newText: "w"
+        }
+      ])
+
+      textChanges = []
+      buffer.undo()
+      expect(textChanges).toEqual([
+        {
+          start: {row: 1, column: 0},
+          oldExtent: {row: 0, column: 2},
+          newExtent: {row: 0, column: 0},
+          newText: ""
+        },
+        {
+          start: {row: 2, column: 3},
+          oldExtent: {row: 0, column: 1},
+          newExtent: {row: 0, column: 0},
+          newText: ""
+        }
+      ])
+
+      textChanges = []
+      buffer.redo()
+      expect(textChanges).toEqual([
         {
           start: {row: 1, column: 0},
           oldExtent: {row: 0, column: 0},
@@ -2385,8 +2415,7 @@ describe "TextBuffer", ->
         buffer.transact ->
           buffer.insert([0, 0], "j")
 
-      expect(textChanges.length).toBe(1)
-      expect(textChanges[0]).toEqual([
+      expect(textChanges).toEqual([
         {
           start: {row: 0, column: 0},
           oldExtent: {row: 0, column: 0},

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2335,7 +2335,7 @@ describe "TextBuffer", ->
 
     it "notifies observers after a transaction, an undo or a redo", ->
       textChanges = []
-      buffer.onDidChangeText (changes) -> textChanges.push(changes...)
+      buffer.onDidChangeText ({changes}) -> textChanges.push(changes...)
 
       buffer.insert([0, 0], "abc")
       buffer.delete([[0, 0], [0, 1]])
@@ -2460,7 +2460,7 @@ describe "TextBuffer", ->
 
       runs ->
         expect(didStopChangingCallback).toHaveBeenCalled()
-        expect(didStopChangingCallback.mostRecentCall.args[0]).toEqual [
+        expect(didStopChangingCallback.mostRecentCall.args[0].changes).toEqual [
           {
             start: {row: 0, column: 0},
             oldExtent: {row: 0, column: 0},

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,3 +1,5 @@
+Point = require './point'
+
 SpliceArrayChunkSize = 100000
 
 module.exports =
@@ -13,3 +15,11 @@ module.exports =
       removedValues
 
   newlineRegex: /\r\n|\n|\r/g
+
+  normalizeChangesObject: (changes) ->
+    changes.map (change) -> {
+      start: Point.fromObject(change.start)
+      oldExtent: Point.fromObject(change.oldExtent)
+      newExtent: Point.fromObject(change.newExtent)
+      newText: change.newText
+    }

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -16,7 +16,7 @@ module.exports =
 
   newlineRegex: /\r\n|\n|\r/g
 
-  normalizeChangesObject: (changes) ->
+  normalizePatchChanges: (changes) ->
     changes.map (change) -> {
       start: Point.fromObject(change.start)
       oldExtent: Point.fromObject(change.oldExtent)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1473,7 +1473,7 @@ class TextBuffer
       markerLayer.emitChangeEvents(snapshot?[markerLayerId])
 
   emitChangeTextEvent: ->
-    @emitter.emit 'did-change-text', Object.freeze(normalizePatchChanges(@didChangeTextPatch.getChanges()))
+    @emitter.emit 'did-change-text', {changes: Object.freeze(normalizePatchChanges(@didChangeTextPatch.getChanges()))}
     @didChangeTextPatch = new Patch(combineChanges: true, batchMode: true)
 
   # Identifies if the buffer belongs to multiple editors.
@@ -1491,7 +1491,7 @@ class TextBuffer
     stoppedChangingCallback = =>
       @stoppedChangingTimeout = null
       modifiedStatus = @isModified()
-      @emitter.emit 'did-stop-changing', Object.freeze(normalizePatchChanges(@stoppedChangingPatch.getChanges()))
+      @emitter.emit 'did-stop-changing', {changes: Object.freeze(normalizePatchChanges(@stoppedChangingPatch.getChanges()))}
       @stoppedChangingPatch = new Patch(combineChanges: true, batchMode: true)
       @emitModifiedStatusChanged(modifiedStatus)
     @stoppedChangingTimeout = setTimeout(stoppedChangingCallback, @stoppedChangingDelay)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -14,7 +14,7 @@ Range = require './range'
 History = require './history'
 MarkerLayer = require './marker-layer'
 MatchIterator = require './match-iterator'
-{spliceArray, newlineRegex, normalizeChangesObject} = require './helpers'
+{spliceArray, newlineRegex, normalizePatchChanges} = require './helpers'
 
 class SearchCallbackArgument
   Object.defineProperty @::, "range",
@@ -1471,7 +1471,7 @@ class TextBuffer
   emitChangeTextEvent: ->
     return unless @didChangeTextPatch?
 
-    @emitter.emit 'did-change-text', Object.freeze(normalizeChangesObject(@didChangeTextPatch.getChanges()))
+    @emitter.emit 'did-change-text', Object.freeze(normalizePatchChanges(@didChangeTextPatch.getChanges()))
     @didChangeTextPatch = null
 
   # Identifies if the buffer belongs to multiple editors.
@@ -1489,7 +1489,7 @@ class TextBuffer
     stoppedChangingCallback = =>
       @stoppedChangingTimeout = null
       modifiedStatus = @isModified()
-      @emitter.emit 'did-stop-changing', Object.freeze(normalizeChangesObject(@stoppedChangingPatch.getChanges()))
+      @emitter.emit 'did-stop-changing', Object.freeze(normalizePatchChanges(@stoppedChangingPatch.getChanges()))
       @stoppedChangingPatch = new Patch
       @emitModifiedStatusChanged(modifiedStatus)
     @stoppedChangingTimeout = setTimeout(stoppedChangingCallback, @stoppedChangingDelay)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -928,6 +928,7 @@ class TextBuffer
       @restoreFromMarkerSnapshot(pop.snapshot)
       @emitMarkerChangeEvents(pop.snapshot)
       @emitChangeTextEvent()
+      @stoppedChangingPatch.rebalance()
       true
     else
       false
@@ -939,6 +940,7 @@ class TextBuffer
       @restoreFromMarkerSnapshot(pop.snapshot)
       @emitMarkerChangeEvents(pop.snapshot)
       @emitChangeTextEvent()
+      @stoppedChangingPatch.rebalance()
       true
     else
       false
@@ -977,7 +979,9 @@ class TextBuffer
     @history.groupChangesSinceCheckpoint(checkpointBefore, endMarkerSnapshot, true)
     @history.applyGroupingInterval(groupingInterval)
     @emitMarkerChangeEvents(endMarkerSnapshot)
-    @emitChangeTextEvent() if @transactCallDepth is 0
+    if @transactCallDepth is 0
+      @emitChangeTextEvent()
+      @stoppedChangingPatch.rebalance()
     result
 
   abortTransaction: ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -741,8 +741,8 @@ class TextBuffer
 
     @changeCount++
     @stoppedChangingPatch.splice(oldRange.start, oldRange.getExtent(), newRange.getExtent(), text: newText)
-    @transactionPatch ?= new Patch
-    @transactionPatch.splice(oldRange.start, oldRange.getExtent(), newRange.getExtent(), text: newText)
+    @didChangeTextPatch ?= new Patch
+    @didChangeTextPatch.splice(oldRange.start, oldRange.getExtent(), newRange.getExtent(), text: newText)
     @emitter.emit 'did-change', changeEvent
 
   # Public: Delete the text in the given range.
@@ -1469,10 +1469,10 @@ class TextBuffer
       markerLayer.emitChangeEvents(snapshot?[markerLayerId])
 
   emitChangeTextEvent: ->
-    return unless @transactionPatch?
+    return unless @didChangeTextPatch?
 
-    @emitter.emit 'did-change-text', Object.freeze(@transactionPatch.getChanges())
-    @transactionPatch = null
+    @emitter.emit 'did-change-text', Object.freeze(@didChangeTextPatch.getChanges())
+    @didChangeTextPatch = null
 
   # Identifies if the buffer belongs to multiple editors.
   #

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -14,7 +14,7 @@ Range = require './range'
 History = require './history'
 MarkerLayer = require './marker-layer'
 MatchIterator = require './match-iterator'
-{spliceArray, newlineRegex} = require './helpers'
+{spliceArray, newlineRegex, normalizeChangesObject} = require './helpers'
 
 class SearchCallbackArgument
   Object.defineProperty @::, "range",
@@ -1471,7 +1471,7 @@ class TextBuffer
   emitChangeTextEvent: ->
     return unless @didChangeTextPatch?
 
-    @emitter.emit 'did-change-text', Object.freeze(@didChangeTextPatch.getChanges())
+    @emitter.emit 'did-change-text', Object.freeze(normalizeChangesObject(@didChangeTextPatch.getChanges()))
     @didChangeTextPatch = null
 
   # Identifies if the buffer belongs to multiple editors.

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1489,7 +1489,7 @@ class TextBuffer
     stoppedChangingCallback = =>
       @stoppedChangingTimeout = null
       modifiedStatus = @isModified()
-      @emitter.emit 'did-stop-changing', Object.freeze(@stoppedChangingPatch.getChanges())
+      @emitter.emit 'did-stop-changing', Object.freeze(normalizeChangesObject(@stoppedChangingPatch.getChanges()))
       @stoppedChangingPatch = new Patch
       @emitModifiedStatusChanged(modifiedStatus)
     @stoppedChangingTimeout = setTimeout(stoppedChangingCallback, @stoppedChangingDelay)


### PR DESCRIPTION
As discussed yesterday, this PR adds the `onDidChangeText` API and closes atom/atom#10610. It felt more important to work on this first, so that we can use it in autocomplete-plus right away.

Two concerns:

1. Maintaining two patches (one for `onDidChangeText` and one for `onDidStopChanging`) is not ideal, as pointed out yesterday, because splicing into them has some cost and I am not sure if/how we can reduce it by reusing one as a starting point for the other. That said, I feel like the splay tree solution that @nathansobo suggested could be enough to make splices fast (a brief profiling session showed that we spend most of the time in tree traversals).
2. I feel like we'd need to change `atom-patch` to support `oldText` in addition to `newText`. This can be addressed in a different PR, as it's not strictly related to `text-buffer`. Still, it seems like a solid addition to the API and would be useful for autocomplete-plus as well.

None of the above is blocking for this PR, though, and we can work directly in `atom-patch` to solve both issues.

/cc: @nathansobo and @maxbrunsfeld for :eyes: 