### PR TITLE
Don’t serialize markers for layers with maintainHistory set to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "8.2.1",
+  "version": "8.2.2-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -899,7 +899,7 @@ describe "TextBuffer", ->
       layer2B = bufferB.getMarkerLayer(layer2A.id)
       expect(layer2B.maintainHistory).toBe true
 
-      expectSameMarkers(layer1A, layer1B)
+      expect(layer1B.getMarkers()).toEqual []
       expectSameMarkers(layer2A, layer2B)
 
     it "doesn't serialize markers with the 'persistent' option set to false", ->

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -246,11 +246,12 @@ class MarkerLayer
     @delegate.markersUpdated(this)
 
   serialize: ->
-    ranges = @index.dump()
     markersById = {}
-    for id in Object.keys(@markersById)
-      marker = @markersById[id]
-      markersById[id] = marker.getSnapshot(Range.fromObject(ranges[id]), false) if marker.persistent
+    if @maintainHistory
+      ranges = @index.dump()
+      for id in Object.keys(@markersById)
+        marker = @markersById[id]
+        markersById[id] = marker.getSnapshot(Range.fromObject(ranges[id]), false) if marker.persistent
     {@id, @maintainHistory, markersById, version: SerializationVersion}
 
   deserialize: (state) ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -104,7 +104,7 @@ class TextBuffer
     maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
     @history = params?.history ? new History(this, maxUndoEntries)
     @nextMarkerLayerId = params?.nextMarkerLayerId ? 0
-    @defaultMarkerLayer = params?.defaultMarkerLayer ? new MarkerLayer(this, String(@nextMarkerLayerId++))
+    @defaultMarkerLayer = params?.defaultMarkerLayer ? new MarkerLayer(this, String(@nextMarkerLayerId++), maintainHistory: true)
     @markerLayers = params?.markerLayers ? {}
     @markerLayers[@defaultMarkerLayer.id] = @defaultMarkerLayer
     @nextMarkerId = params?.nextMarkerId ? 1


### PR DESCRIPTION
This is to address a performance problem we're seeing in https://github.com/atom/atom/pull/10605