### PR TITLE
Compose changes instead of splicing into did-stop-changing Patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "delegato": "^1.0.0",
     "atom-diff": "^2",
-    "atom-patch": "0.0.8",
+    "atom-patch": "0.1.0",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",
     "fs-plus": "^2.0.0",

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -18,7 +18,7 @@ module.exports =
 
   normalizePatchChanges: (changes) ->
     changes.map (change) -> {
-      start: Point.fromObject(change.start)
+      start: Point.fromObject(change.newStart)
       oldExtent: Point.fromObject(change.oldExtent)
       newExtent: Point.fromObject(change.newExtent)
       newText: change.newText


### PR DESCRIPTION
Depends on: https://github.com/atom/atom-patch/pull/4, more information there on why/how this is faster.

/cc: @atom/core 