### PR TITLE
Do not serialize range when serializing snapshots

### DIFF
--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -19,13 +19,7 @@ class MarkerLayer
     store
 
   @serializeSnapshot: (snapshot) ->
-    result = {}
-    for layerId, markerSnapshots of snapshot
-      result[layerId] = {}
-      for markerId, markerSnapshot of markerSnapshots
-        result[layerId][markerId] = clone(markerSnapshot)
-        result[layerId][markerId].range = markerSnapshot.range.serialize()
-    result
+    snapshot
 
   @deserializeSnapshot: (snapshot) ->
     result = {}
@@ -33,7 +27,7 @@ class MarkerLayer
       result[layerId] = {}
       for markerId, markerSnapshot of markerSnapshots
         result[layerId][markerId] = clone(markerSnapshot)
-        result[layerId][markerId].range = Range.deserialize(markerSnapshot.range)
+        result[layerId][markerId].range = Range.fromObject(markerSnapshot.range)
     result
 
   ###


### PR DESCRIPTION
Ranges will be automatically serialized to objects with a structure similar to `{start: {row: y1, column: x1}, end: {row: y2, column: x2}}`, which we can easily deserialize by calling `Range.fromObject`. Since marker snapshots are, by design, immutable data structures, we can avoid the performance drag of cloning them for serialization purposes. This is similar to what we do already in [MarkerLayer.serialize](https://github.com/atom/text-buffer/blob/master/src/marker-layer.coffee#L253).

_On a side note, I have also tried to replace `underscore.clone(object)` with `Object.assign({}, object)`, but performance-wise they have the same cost. Also trying to clone the object by hand has a `20ms` overhead (that grows as we add more snapshots) for the same benchmarks below._

#### Before

![screen shot 2016-02-23 at 16 14 23](https://cloud.githubusercontent.com/assets/482957/13255877/86d36a9a-da48-11e5-96e0-93bd2fccdc37.png)

_(**Total:** `~ 62.6ms`, benchmarks performed after inserting 15 characters on 1500 cursors)_

#### After

![screen shot 2016-02-23 at 16 13 14](https://cloud.githubusercontent.com/assets/482957/13255921/c35a1194-da48-11e5-8b43-87693e74a419.png)

_(**Total:** `~ 1.2ms`, ~ 50x faster :racehorse:)_

This doesn't seem to have an impact on deserialization, as the code path looks almost identical to what it was before. Even more importantly, these numbers won't grow as `History` gets larger, because we are not iterating over snapshots and cloning them anymore. 

#### Ending Thoughts

Because `serialize` calls will become quite faster, this PR may open up a scenario where we could:

1. Synchronously call `serialize` and save the state somewhere after each keystroke or mouse event.
2. `JSON.stringify` the object graph across multiple `requestIdleCallback`s.

Ideally, this would further reduce the pressure on the main thread, although it doesn't come without shortcomings (e.g. what do we do when too many chunks of work start to queue up? Maybe not a problem in practice, but something to keep in mind). 

What do you think? :thought_balloon: 

/cc: @nathansobo @maxbrunsfeld @kuychaco 