### PR TITLE
Stop using a forked version of `diff`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "delegato": "^1.0.0",
-    "atom-diff": "^2",
+    "diff": "^2.2.1",
     "atom-patch": "0.2.0",
     "emissary": "^1.0.0",
     "event-kit": "^1.0.2",

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1183,15 +1183,15 @@ describe "TextBuffer", ->
         expect(calls).toBe(0)
 
       it "changes the in-memory contents of the buffer to match the new disk contents and notifies ::onDidChange observers", ->
-        expect(event1.oldRange).toEqual [[0, 0], [0, 0]]
-        expect(event1.newRange).toEqual [[0, 0], [0, 6]]
-        expect(event1.oldText).toBe ""
-        expect(event1.newText).toBe "second"
+        expect(event1.oldRange).toEqual [[0, 0], [0, 5]]
+        expect(event1.newRange).toEqual [[0, 0], [0, 0]]
+        expect(event1.oldText).toBe "first"
+        expect(event1.newText).toBe ""
 
-        expect(event2.oldRange).toEqual [[0, 6], [0, 11]]
-        expect(event2.newRange).toEqual [[0, 6], [0, 6]]
-        expect(event2.oldText).toBe "first"
-        expect(event2.newText).toBe ""
+        expect(event2.oldRange).toEqual [[0, 0], [0, 0]]
+        expect(event2.newRange).toEqual [[0, 0], [0, 6]]
+        expect(event2.oldText).toBe ""
+        expect(event2.newText).toBe "second"
 
         expect(buffer.isModified()).toBeFalsy()
 
@@ -1685,10 +1685,16 @@ describe "TextBuffer", ->
 
     describe "when the buffer contains carriage returns for newlines", ->
       it "can replace the contents of the buffer", ->
-        buffer = new TextBuffer("first\rsecond\rlast")
-        newText = "new first\rnew last"
+        originalText = "beginning\rmiddle\rlast"
+        newText = "new beginning\rnew last"
+        buffer = new TextBuffer(originalText)
+        expect(buffer.getText()).toBe originalText
+
         buffer.setTextViaDiff(newText)
         expect(buffer.getText()).toBe newText
+
+        buffer.setTextViaDiff(originalText)
+        expect(buffer.getText()).toBe originalText
 
   describe "::save()", ->
     saveBuffer = null

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -605,14 +605,15 @@ class TextBuffer
       changeOptions = normalizeLineEndings: false
 
       for change in lineDiff
+        # Using change.count does not account for lone carriage-returns
         lineCount = change.value.match(newlineRegex)?.length ? 0
         currentPosition[0] = row
         currentPosition[1] = column
 
         if change.added
-          @setTextInRange([currentPosition, currentPosition], change.value, changeOptions)
           row += lineCount
           column = computeBufferColumn(change.value)
+          @setTextInRange([currentPosition, currentPosition], change.value, changeOptions)
 
         else if change.removed
           endRow = row + lineCount

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1,7 +1,7 @@
 {Emitter, CompositeDisposable} = require 'event-kit'
 {File} = require 'pathwatcher'
 SpanSkipList = require 'span-skip-list'
-diff = require 'atom-diff'
+diff = require 'diff'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'


### PR DESCRIPTION
The only change in the forked version was merged into the main repo 2+ years ago.

Fixes #137

/cc @ArekSredzki, @kevinsawicki, @benogle