### PR TITLE
Don’t throw an error when clearing the undo stack within a transaction

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2439,6 +2439,11 @@ describe "TextBuffer", ->
         }
       ])
 
+    it "doesn't throw an error when clearing the undo stack within a transaction", ->
+      buffer.onDidChangeText(didChangeTextSpy = jasmine.createSpy())
+      expect(-> buffer.transact(-> buffer.clearUndoStack())).not.toThrowError()
+      expect(didChangeTextSpy).not.toHaveBeenCalled()
+
   describe "::onDidStopChanging(callback)", ->
     [delay, didStopChangingCallback] = []
     beforeEach (done) ->

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -281,6 +281,22 @@ class History
   clearRedoStack: ->
     @redoStack.length = 0
 
+  toString: ->
+    output = ''
+    for entry in @undoStack
+      switch entry.constructor
+        when Checkpoint
+          output += "Checkpoint, "
+        when GroupStart
+          output += "GroupStart, "
+        when GroupEnd
+          output += "GroupEnd, "
+        when Patch
+          output += "Patch, "
+        else
+          output += "Unknown {#{JSON.stringify(entry)}}, "
+    '[' + output.slice(0, -2) + ']'
+
   serialize: (options) ->
     version: SerializationVersion
     nextCheckpointId: @nextCheckpointId

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -989,7 +989,7 @@ class TextBuffer
 
   # Public: Clear the undo stack. When calling this method within a transaction,
   # the {::onDidChangeText} event will not be triggered because the information
-  # which describes the changes is lost.
+  # describing the changes is lost.
   clearUndoStack: -> @history.clearUndoStack()
 
   # Public: Create a pointer to the current state of the buffer for use

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -979,6 +979,8 @@ class TextBuffer
 
     endMarkerSnapshot = @createMarkerSnapshot()
     compactedChanges = @history.groupChangesSinceCheckpoint(checkpointBefore, endMarkerSnapshot, true)
+    global.atom?.assert compactedChanges, "groupChangesSinceCheckpoint() returned false.", (error) ->
+      error.metadata = {history: @history.toString()}
     @history.applyGroupingInterval(groupingInterval)
     @emitMarkerChangeEvents(endMarkerSnapshot)
     @emitDidChangeTextEvent(compactedChanges) if compactedChanges

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -981,13 +981,15 @@ class TextBuffer
     compactedChanges = @history.groupChangesSinceCheckpoint(checkpointBefore, endMarkerSnapshot, true)
     @history.applyGroupingInterval(groupingInterval)
     @emitMarkerChangeEvents(endMarkerSnapshot)
-    @emitDidChangeTextEvent(compactedChanges)
+    @emitDidChangeTextEvent(compactedChanges) if compactedChanges
     result
 
   abortTransaction: ->
     throw new TransactionAbortedError("Transaction aborted.")
 
-  # Public: Clear the undo stack.
+  # Public: Clear the undo stack. When calling this method within a transaction,
+  # the {::onDidChangeText} event will not be triggered because the information
+  # which describes the changes is lost.
   clearUndoStack: -> @history.clearUndoStack()
 
   # Public: Create a pointer to the current state of the buffer for use


### PR DESCRIPTION
...because it prevents our ability to go back to a checkpoint and compact the changes in order to emit a `did-change-text` event.

Refs: https://github.com/atom/atom/issues/11234

/cc: @atom/core 