### PR TITLE
Simplify undo history structure and stack truncation

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -351,31 +351,20 @@ describe "TextBuffer", ->
     it "does not allow the undo stack to grow without bound", ->
       buffer = new TextBuffer(maxUndoEntries: 12)
 
-      # A transaction with 1 change uses 3 undo entries, so we can undo 4 of
-      # these transactions.
-      for i in [1...10]
-        buffer.append("#{i}\n")
-      expect(buffer.getLineCount()).toBe 10
-
-      undoCount = 0
-      undoCount++ while buffer.undo()
-      expect(undoCount).toBe 4
-      expect(buffer.getLineCount()).toBe 6
-
-      # A transaction with 2 changes uses 4 undo entries, so we can undo 3 of
-      # these transactions.
+      # Each transaction is treated as a single undo entry. We can undo up
+      # to 12 of them.
       buffer.setText("")
       buffer.clearUndoStack()
-      for i in [1...10]
+      for i in [0...13]
         buffer.transact ->
           buffer.append(String(i))
           buffer.append("\n")
-      expect(buffer.getLineCount()).toBe 10
+      expect(buffer.getLineCount()).toBe 14
 
       undoCount = 0
       undoCount++ while buffer.undo()
-      expect(undoCount).toBe 3
-      expect(buffer.getLineCount()).toBe 7
+      expect(undoCount).toBe 12
+      expect(buffer.getText()).toBe '0\n'
 
   describe "transactions", ->
     now = null

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -217,6 +217,7 @@ class History
     nextCheckpointId: @nextCheckpointId
     undoStack: @serializeStack(@undoStack, options)
     redoStack: @serializeStack(@redoStack, options)
+    maxUndoEntries: @maxUndoEntries
 
   deserialize: (state) ->
     return unless state.version is SerializationVersion

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -1,7 +1,7 @@
 Patch = require 'atom-patch'
 MarkerLayer = require './marker-layer'
 
-SerializationVersion = 4
+SerializationVersion = 5
 
 class Checkpoint
   constructor: (@id, @snapshot, @isBoundary) ->
@@ -9,13 +9,21 @@ class Checkpoint
       global.atom?.assert(false, "Checkpoint created without snapshot")
       @snapshot = {}
 
-class GroupStart
-  constructor: (@snapshot) ->
-
-class GroupEnd
-  constructor: (@snapshot) ->
+class Transaction
+  constructor: (@markerSnapshotBefore, @patch, @markerSnapshotAfter, @groupingInterval=0) ->
     @timestamp = Date.now()
-    @groupingInterval = 0
+
+  shouldGroupWith: (previousTransaction) ->
+    timeBetweenTransactions = @timestamp - previousTransaction.timestamp
+    timeBetweenTransactions < Math.min(@groupingInterval, previousTransaction.groupingInterval)
+
+  groupWith: (previousTransaction) ->
+    new Transaction(
+      previousTransaction.markerSnapshotBefore,
+      Patch.compose([previousTransaction.patch, @patch]),
+      @markerSnapshotAfter,
+      @groupingInterval
+    )
 
 # Manages undo/redo for {TextBuffer}
 module.exports =
@@ -27,150 +35,90 @@ class History
 
   constructor: (@maxUndoEntries) ->
     @nextCheckpointId = 0
-    @undoStackSize = 0
     @undoStack = []
     @redoStack = []
 
   createCheckpoint: (snapshot, isBoundary) ->
     checkpoint = new Checkpoint(@nextCheckpointId++, snapshot, isBoundary)
     @undoStack.push(checkpoint)
-    @undoStackSize += 1
     checkpoint.id
 
-  groupChangesSinceCheckpoint: (checkpointId, endSnapshot, deleteCheckpoint=false) ->
-    withinGroup = false
+  groupChangesSinceCheckpoint: (checkpointId, markerSnapshotAfter, deleteCheckpoint=false) ->
     checkpointIndex = null
-    startSnapshot = null
+    markerSnapshotBefore = null
     patchesSinceCheckpoint = []
-    previousStackSize = @undoStack
 
     for entry, i in @undoStack by -1
       break if checkpointIndex?
 
       switch entry.constructor
-        when GroupEnd
-          withinGroup = true
-          @undoStackSize -= 1
-        when GroupStart
-          if withinGroup
-            withinGroup = false
-            @undoStackSize -= 1
-          else
-            @undoStackSize = previousStackSize
-            return false
         when Checkpoint
           if entry.id is checkpointId
             checkpointIndex = i
-            startSnapshot = entry.snapshot
+            markerSnapshotBefore = entry.snapshot
           else if entry.isBoundary
-            @undoStackSize = previousStackSize
             return false
-        else
-          @undoStackSize -= entry.getChanges().length
+        when Transaction
+          patchesSinceCheckpoint.unshift(entry.patch)
+        when Patch
           patchesSinceCheckpoint.unshift(entry)
+        else
+          throw new Error("Unexpected undo stack entry type: #{entry.constructor.name}")
 
     if checkpointIndex?
       composedPatches = Patch.compose(patchesSinceCheckpoint)
       if patchesSinceCheckpoint.length > 0
         @undoStack.splice(checkpointIndex + 1)
-        @undoStack.push(new GroupStart(startSnapshot))
-        @undoStack.push(composedPatches)
-        @undoStack.push(new GroupEnd(endSnapshot))
-        @undoStackSize += composedPatches.getChanges().length + 2
+        @undoStack.push(new Transaction(markerSnapshotBefore, composedPatches, markerSnapshotAfter))
       if deleteCheckpoint
         @undoStack.splice(checkpointIndex, 1)
-        @undoStackSize -= 1
       composedPatches
     else
       false
 
+  enforceUndoStackSizeLimit: ->
+    if @undoStack.length > @maxUndoEntries
+      @undoStack.splice(0, @undoStack.length - @maxUndoEntries)
+
   applyGroupingInterval: (groupingInterval) ->
     topEntry = @undoStack[@undoStack.length - 1]
-    if topEntry instanceof GroupEnd
+    previousEntry = @undoStack[@undoStack.length - 2]
+
+    if topEntry instanceof Transaction
       topEntry.groupingInterval = groupingInterval
     else
       return
 
     return if groupingInterval is 0
 
-    for entry, i in @undoStack by -1
-      if entry instanceof GroupStart
-        previousEntry = @undoStack[i - 1]
-        if previousEntry instanceof GroupEnd
-          if (topEntry.timestamp - previousEntry.timestamp < Math.min(previousEntry.groupingInterval, groupingInterval))
-            previousPatch = @undoStack[i - 2]
-            currentPatch = @undoStack[i + 1]
-            @undoStack.splice(i - 2, 4, Patch.compose([previousPatch, currentPatch]))
-        return
-
-    throw new Error("Didn't find matching group-start entry")
+    if previousEntry instanceof Transaction and topEntry.shouldGroupWith(previousEntry)
+      @undoStack.splice(@undoStack.length - 2, 2, topEntry.groupWith(previousEntry))
 
   pushChange: (change) ->
     @undoStack.push(Patch.hunk(change))
     @clearRedoStack()
-    @undoStackSize += 1
-
-    if @undoStackSize > @maxUndoEntries
-      spliceIndex = null
-      withinGroup = false
-      for entry, i in @undoStack
-        break if spliceIndex?
-        switch entry.constructor
-          when GroupStart
-            if withinGroup
-              throw new Error("Invalid undo stack state")
-            else
-              withinGroup = true
-              @undoStackSize -= 1
-          when GroupEnd
-            if withinGroup
-              spliceIndex = i
-              @undoStackSize -= 1
-            else
-              throw new Error("Invalid undo stack state")
-          when Patch
-            @undoStackSize -= entry.getChanges().length
-            unless withinGroup
-              spliceIndex = i
-
-      @undoStack.splice(0, spliceIndex + 1) if spliceIndex?
 
   popUndoStack: ->
     snapshotBelow = null
-    spliceIndex = null
-    withinGroup = false
     patch = null
-    previousStackSize = @undoStackSize
+    spliceIndex = null
 
     for entry, i in @undoStack by -1
       break if spliceIndex?
 
       switch entry.constructor
-        when GroupStart
-          if withinGroup
-            snapshotBelow = entry.snapshot
-            spliceIndex = i
-            @undoStackSize -= 1
-          else
-            @undoStackSize = previousStackSize
-            return false
-        when GroupEnd
-          if withinGroup
-            throw new Error("Invalid undo stack state")
-          else
-            withinGroup = true
-            @undoStackSize -= 1
         when Checkpoint
           if entry.isBoundary
-            @undoStackSize = previousStackSize
             return false
-          else
-            @undoStackSize -= 1
-        else
+        when Transaction
+          snapshotBelow = entry.markerSnapshotBefore
+          patch = Patch.invert(entry.patch)
+          spliceIndex = i
+        when Patch
           patch = Patch.invert(entry)
-          @undoStackSize -= patch.getChanges().length
-          unless withinGroup
-            spliceIndex = i
+          spliceIndex = i
+        else
+          throw new Error("Unexpected entry type when popping undoStack: #{entry.constructor.name}")
 
     if spliceIndex?
       @redoStack.push(@undoStack.splice(spliceIndex).reverse()...)
@@ -183,39 +131,25 @@ class History
 
   popRedoStack: ->
     snapshotBelow = null
-    spliceIndex = null
-    withinGroup = false
     patch = null
-    previousStackSize = @undoStackSize
+    spliceIndex = null
 
     for entry, i in @redoStack by -1
       break if spliceIndex?
 
       switch entry.constructor
-        when GroupEnd
-          if withinGroup
-            snapshotBelow = entry.snapshot
-            spliceIndex = i
-            @undoStackSize += 1
-          else
-            @undoStackSize = previousStackSize
-            return false
-        when GroupStart
-          if withinGroup
-            throw new Error("Invalid redo stack state")
-          else
-            @undoStackSize += 1
-            withinGroup = true
         when Checkpoint
           if entry.isBoundary
             throw new Error("Invalid redo stack state")
-          else
-            @undoStackSize += 1
-        else
+        when Transaction
+          snapshotBelow = entry.markerSnapshotAfter
+          patch = entry.patch
+          spliceIndex = i
+        when Patch
           patch = entry
-          @undoStackSize += patch.getChanges().length
-          unless withinGroup
-            spliceIndex = i
+          spliceIndex = i
+        else
+          throw new Error("Unexpected entry type when popping redoStack: #{entry.constructor.name}")
 
     while @redoStack[spliceIndex - 1] instanceof Checkpoint
       spliceIndex--
@@ -232,39 +166,22 @@ class History
   truncateUndoStack: (checkpointId) ->
     snapshotBelow = null
     spliceIndex = null
-    withinGroup = false
     patchesSinceCheckpoint = []
-    previousStackSize = @undoStackSize
 
     for entry, i in @undoStack by -1
       break if spliceIndex?
 
       switch entry.constructor
-        when GroupStart
-          if withinGroup
-            withinGroup = false
-            @undoStackSize -= 1
-          else
-            @undoStackSize = previousStackSize
-            return false
-        when GroupEnd
-          if withinGroup
-            throw new Error("Invalid undo stack state")
-          else
-            withinGroup = true
-            @undoStackSize -= 1
         when Checkpoint
           if entry.id is checkpointId
-            spliceIndex = i
             snapshotBelow = entry.snapshot
-            @undoStackSize -= 1
+            spliceIndex = i
           else if entry.isBoundary
-            @undoStackSize = previousStackSize
             return false
+        when Transaction
+          patchesSinceCheckpoint.push(Patch.invert(entry.patch))
         else
-          patch = Patch.invert(entry)
-          patchesSinceCheckpoint.push(patch)
-          @undoStackSize -= patch.getChanges().length
+          patchesSinceCheckpoint.push(Patch.invert(entry))
 
     if spliceIndex?
       @undoStack.splice(spliceIndex)
@@ -287,10 +204,8 @@ class History
       switch entry.constructor
         when Checkpoint
           output += "Checkpoint, "
-        when GroupStart
-          output += "GroupStart, "
-        when GroupEnd
-          output += "GroupEnd, "
+        when Transaction
+          output += "Transaction, "
         when Patch
           output += "Patch, "
         else
@@ -330,21 +245,20 @@ class History
             snapshot: @serializeSnapshot(entry.snapshot, options)
             isBoundary: entry.isBoundary
           }
-        when GroupStart
+        when Transaction
           {
-            type: 'group-start'
-            snapshot: @serializeSnapshot(entry.snapshot, options)
+            type: 'transaction'
+            markerSnapshotBefore: @serializeSnapshot(entry.markerSnapshotBefore, options)
+            markerSnapshotAfter: @serializeSnapshot(entry.markerSnapshotAfter, options)
+            patch: entry.patch.serialize()
           }
-        when GroupEnd
-          {
-            type: 'group-end'
-            snapshot: @serializeSnapshot(entry.snapshot, options)
-          }
-        else
+        when Patch
           {
             type: 'patch'
             content: entry.serialize()
           }
+        else
+          throw new Error("Unexpected undoStack entry type during serialization: #{entry.constructor.name}")
 
   deserializeStack: (stack) ->
     for entry in stack
@@ -355,16 +269,16 @@ class History
             MarkerLayer.deserializeSnapshot(entry.snapshot)
             entry.isBoundary
           )
-        when 'group-start'
-          new GroupStart(
-            MarkerLayer.deserializeSnapshot(entry.snapshot)
-          )
-        when 'group-end'
-          new GroupEnd(
-            MarkerLayer.deserializeSnapshot(entry.snapshot)
+        when 'transaction'
+          new Transaction(
+            MarkerLayer.deserializeSnapshot(entry.markerSnapshotBefore)
+            Patch.deserialize(entry.patch)
+            MarkerLayer.deserializeSnapshot(entry.markerSnapshotAfter)
           )
         when 'patch'
           Patch.deserialize(entry.content)
+        else
+          throw new Error("Unexpected undoStack entry type during deserialization: #{entry.type}")
 
   serializeSnapshot: (snapshot, options) ->
     return unless options.markerLayers

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -982,6 +982,7 @@ class TextBuffer
     global.atom?.assert compactedChanges, "groupChangesSinceCheckpoint() returned false.", (error) =>
       error.metadata = {history: @history.toString()}
     @history.applyGroupingInterval(groupingInterval)
+    @history.enforceUndoStackSizeLimit()
     @emitMarkerChangeEvents(endMarkerSnapshot)
     @emitDidChangeTextEvent(compactedChanges) if compactedChanges
     result


### PR DESCRIPTION
Fixes atom/atom#11234

This PR changes the way we store groups of changes in the undo history. Previously, we were still using the `GroupStart` and `GroupEnd` objects that were necessary when we stored temporally-ordered changes in the history rather than patches. Now that we use patches, however, this representation is no longer necessary. We replaced it with a simple `Transaction` object that has the before and after marker snapshots along with a composed patch representing the set of all changes. Now undo history contains the following kinds of objects: `Checkpoint`, `Patch`, and `Transaction`.

We also simplify our approach to limiting the size of the undo stack. Rather than attempting to count individual changes, we just base everything on the length of the undo stack itself. This means the stack can grow larger in memory terms in the presence of many large multi-cursor edits, but we think these kinds of operations represent a small enough percentage of the typical editing workload so as to not grossly affect the overall size of the history. If this is a problem in the future, we can reintroduce a solution that tries to account for the real size of the stack. We're worried that this complexity isn't worth it for now, however.