### PR TITLE
Improve behavior when files are changed/deleted after TextBuffer has been serialized

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1078,16 +1078,14 @@ describe "TextBuffer", ->
             buffer2.setText(previousText)
             expect(buffer2.isModified()).toBeFalsy()
 
-      describe "when the serialized buffer was unsaved and had no path", ->
-        it "restores the previous unsaved state of the buffer", ->
-          buffer.destroy()
+    describe "when the serialized buffer was unsaved and had no path", ->
+      it "restores the previous unsaved state of the buffer", ->
+        buffer = new TextBuffer()
+        buffer.setText("abc")
 
-          buffer = new TextBuffer()
-          buffer.setText("abc")
-
-          buffer2 = TextBuffer.deserialize(buffer.serialize())
-          expect(buffer2.getPath()).toBeUndefined()
-          expect(buffer2.getText()).toBe("abc")
+        buffer2 = TextBuffer.deserialize(buffer.serialize())
+        expect(buffer2.getPath()).toBeUndefined()
+        expect(buffer2.getText()).toBe("abc")
 
   describe "::getRange()", ->
     it "returns the range of the entire buffer text", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1335,27 +1335,19 @@ describe "TextBuffer", ->
         expect(bufferToDelete.isModified()).toBeTruthy()
 
     describe "when the file is not modified", ->
-      [previousContents, modifiedEvents] = []
-
       beforeEach (done) ->
-        previousContents = bufferToDelete.getText()
-        modifiedEvents = []
         expect(bufferToDelete.isModified()).toBeFalsy()
-        bufferToDelete.onDidChangeModified (modified) -> modifiedEvents.push(modified)
         bufferToDelete.file.onDidDelete ->
           done()
         fs.removeSync(filePath)
 
-      it "retains its path and reports the buffer as modified", ->
+      it "retains its path and reports the buffer as not modified", ->
         # FIXME: This doesn't pass on Linux
         return if process.platform is 'linux'
 
-        expect(modifiedEvents).toEqual [true]
         expect(bufferToDelete.getPath()).toBe filePath
-        expect(bufferToDelete.isModified()).toBeTruthy()
-        expect(bufferToDelete.isInConflict()).toBeFalsy()
-        expect(bufferToDelete.isDestroyed()).toBeFalsy()
-        expect(bufferToDelete.getText()).toBe(previousContents)
+        expect(bufferToDelete.isModified()).toBeFalsy()
+
 
     describe "when the file is deleted", ->
       it "notifies all onDidDelete listeners ", (done) ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1335,19 +1335,27 @@ describe "TextBuffer", ->
         expect(bufferToDelete.isModified()).toBeTruthy()
 
     describe "when the file is not modified", ->
+      [previousContents, modifiedEvents] = []
+
       beforeEach (done) ->
+        previousContents = bufferToDelete.getText()
+        modifiedEvents = []
         expect(bufferToDelete.isModified()).toBeFalsy()
+        bufferToDelete.onDidChangeModified (modified) -> modifiedEvents.push(modified)
         bufferToDelete.file.onDidDelete ->
           done()
         fs.removeSync(filePath)
 
-      it "retains its path and reports the buffer as not modified", ->
+      it "retains its path and reports the buffer as modified", ->
         # FIXME: This doesn't pass on Linux
         return if process.platform is 'linux'
 
+        expect(modifiedEvents).toEqual [true]
         expect(bufferToDelete.getPath()).toBe filePath
-        expect(bufferToDelete.isModified()).toBeFalsy()
-
+        expect(bufferToDelete.isModified()).toBeTruthy()
+        expect(bufferToDelete.isInConflict()).toBeFalsy()
+        expect(bufferToDelete.isDestroyed()).toBeFalsy()
+        expect(bufferToDelete.getText()).toBe(previousContents)
 
     describe "when the file is deleted", ->
       it "notifies all onDidDelete listeners ", (done) ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -382,7 +382,7 @@ class TextBuffer
       if @file.existsSync()
         @getText() != @cachedDiskContents
       else
-        not @isEmpty()
+        @wasModifiedBeforeRemove ? not @isEmpty()
     else
       not @isEmpty()
 
@@ -1523,9 +1523,13 @@ class TextBuffer
         @reload()
 
     @fileSubscriptions.add @file.onDidDelete =>
+      modified = @getText() != @cachedDiskContents
+      @wasModifiedBeforeRemove = modified
       @emitter.emit 'did-delete'
-      @updateCachedDiskContents()
-      @emitModifiedStatusChanged(@isModified())
+      if modified
+        @updateCachedDiskContents()
+      else
+        @destroy()
 
     @fileSubscriptions.add @file.onDidRename =>
       @emitter.emit 'did-change-path', @getPath()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1474,7 +1474,7 @@ class TextBuffer
         @reload(true)
       else if @isModified() and @file?.existsSync()
         if @digestWhenLastPersisted is @getTextDigest()
-          @reload(true)
+          @reload()
         else
           @conflict = @digestWhenLastPersisted isnt @file?.getDigestSync()
           @emitModifiedStatusChanged(true)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1479,6 +1479,7 @@ class TextBuffer
           @conflict = true
 
       @emitModifiedStatusChanged(@isModified())
+    this
 
   destroy: ->
     unless @destroyed

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -382,7 +382,7 @@ class TextBuffer
       if @file.existsSync()
         @getText() != @cachedDiskContents
       else
-        @wasModifiedBeforeRemove ? not @isEmpty()
+        not @isEmpty()
     else
       not @isEmpty()
 
@@ -1522,13 +1522,9 @@ class TextBuffer
         @reload()
 
     @fileSubscriptions.add @file.onDidDelete =>
-      modified = @getText() != @cachedDiskContents
-      @wasModifiedBeforeRemove = modified
       @emitter.emit 'did-delete'
-      if modified
-        @updateCachedDiskContents()
-      else
-        @destroy()
+      @updateCachedDiskContents()
+      @emitModifiedStatusChanged(@isModified())
 
     @fileSubscriptions.add @file.onDidRename =>
       @emitter.emit 'did-change-path', @getPath()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1472,14 +1472,13 @@ class TextBuffer
       @loaded = true
       if not @digestWhenLastPersisted
         @reload(true)
-      else if @isModified() and @file?.existsSync()
+      else if @file?.existsSync() and @isModified()
         if @digestWhenLastPersisted is @getTextDigest()
           @reload()
-        else
-          @conflict = @digestWhenLastPersisted isnt @file?.getDigestSync()
-          @emitModifiedStatusChanged(true)
-      else
-        @emitModifiedStatusChanged(false)
+        else if @digestWhenLastPersisted isnt @file?.getDigestSync()
+          @conflict = true
+
+      @emitModifiedStatusChanged(@isModified())
 
   destroy: ->
     unless @destroyed


### PR DESCRIPTION
This pull-request aims at improving the experience when files get changed or deleted after serializing a `TextBuffer` instance. In particular, these scenarios have been changed:

1. When serializing a buffer, deleting the underlying file and then deserializing the buffer.
  1. **Before this pull-request.** Clear the text and the undo stack.
  1. **After this pull-request.** Keep the text at the moment of serialization, mark the buffer as modified.
1. When serializing a buffer with unsaved changes, changing the underlying file and then deserializing the buffer.
  1. **Before this pull-request.** Reload the file, and clear the undo stack.
  1. **After this pull-request.** Keep the text at the moment of serialization, mark the buffer as modified, mark the buffer as _in conflict_.
1. When serializing a buffer with no unsaved changes, changing the underlying file and then deserializing the buffer.
  1. **Before this pull-request.** Reload the file, and clear the undo stack.
  1. **After this pull-request.** Reload the file, and keep the undo stack.

This should result in a more robust experience, thereby preventing users from feeling like they've lost work, but still trying to update the file to the latest version on disk when there are no conflicts and no pending changes.

/cc: @atom/core 