### PR TITLE
Add DisplayLayer.prototype.softWrapDescriptorForScreenRow

### DIFF
--- a/spec/display-layer-spec.coffee
+++ b/spec/display-layer-spec.coffee
@@ -430,6 +430,19 @@ describe "DisplayLayer", ->
         [Point(2, 7), Point(0, 12)],
       ])
 
+    it "allows to query the soft-wrap descriptor of each screen row", ->
+      buffer = new TextBuffer(text: 'abc def ghi\njkl mno pqr')
+      displayLayer = buffer.addDisplayLayer(softWrapColumn: 4)
+
+      expect(JSON.stringify(displayLayer.getText())).toBe JSON.stringify("abc \ndef \nghi\njkl \nmno \npqr")
+
+      expect(displayLayer.softWrapDescriptorForScreenRow(0)).toEqual {softWrappedAtStart: false, softWrappedAtEnd: true, bufferRow: 0}
+      expect(displayLayer.softWrapDescriptorForScreenRow(1)).toEqual {softWrappedAtStart: true, softWrappedAtEnd: true, bufferRow: 0}
+      expect(displayLayer.softWrapDescriptorForScreenRow(2)).toEqual {softWrappedAtStart: true, softWrappedAtEnd: false, bufferRow: 0}
+      expect(displayLayer.softWrapDescriptorForScreenRow(3)).toEqual {softWrappedAtStart: false, softWrappedAtEnd: true, bufferRow: 1}
+      expect(displayLayer.softWrapDescriptorForScreenRow(4)).toEqual {softWrappedAtStart: true, softWrappedAtEnd: true, bufferRow: 1}
+      expect(displayLayer.softWrapDescriptorForScreenRow(5)).toEqual {softWrappedAtStart: true, softWrappedAtEnd: false, bufferRow: 1}
+
     it "prefers the skipSoftWrapIndentation option over clipDirection when translating points", ->
       buffer = new TextBuffer(text: '   abc defgh')
       displayLayer = buffer.addDisplayLayer(softWrapColumn: 8, softWrapHangingIndent: 2)

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -1131,6 +1131,14 @@ class DisplayLayer
 
     Point.fromObject(screenPosition)
 
+  softWrapDescriptorForScreenRow: (row) ->
+    @spatialLineIterator.seekToScreenRow(row)
+    {
+      softWrappedAtStart: @spatialLineIterator.isSoftWrappedAtStart(),
+      softWrappedAtEnd: @spatialLineIterator.isSoftWrappedAtEnd(),
+      bufferRow: @spatialLineIterator.getBufferStart().row
+    }
+
   getScreenLineCount: ->
     @displayIndex.getScreenLineCount()
 


### PR DESCRIPTION
This new private API can be used in `TextEditorPresenter` to efficiently render line-numbers in the gutter by querying the `DisplayLayer`'s spatial information just once. We call this a soft-wrap descriptor, because it describes if and how a row has been soft-wrapped, including which buffer row it belongs to.

/cc: @atom/core 