### PR TITLE
Don't watch backup files

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grim": "1.5.0",
     "line-length-index": "0.0.2",
     "marker-index": "4.0.0",
-    "pathwatcher": "6.6.0",
+    "pathwatcher": "6.6.1",
     "serializable": "^1.0.3",
     "span-skip-list": "~0.2.0",
     "underscore-plus": "^1.0.0"

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1411,7 +1411,7 @@ class TextBuffer
         throw new Error("Can't create a backup file for #{@getPath()} because files already exist at every candidate path.")
       backupFilePath += '~'
 
-    file = new File(backupFilePath)
+    file = new File(backupFilePath, false, false)
     file.safeWriteSync(@file.readSync())
     file
 


### PR DESCRIPTION
Watching happens automatically if there is any file subscription. Unfortunately some subscriptions are added automatically if Grim.includeDeprecatedAPIs equals `true`, which is the case for Atom too.
We fix this by not including deprecated APIs when instantiating the backup `File`.