### PR TITLE
Restore assignment of properties in MarkerLayer.prototype.markPosition

### DIFF
--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -73,6 +73,10 @@ describe "Marker", ->
         expect(buffer.findMarkers({})).toEqual [marker1]
         expect(buffer.getMarkers()).toEqual [marker1]
 
+      it "allows arbitrary properties to be assigned", ->
+        marker = buffer.markRange([[0, 6], [0, 8]], foo: 'bar')
+        expect(marker.getProperties()).toEqual({foo: 'bar'})
+
     describe "TextBuffer::markPosition(position, properties)", ->
       it "creates a tail-less marker at the given position", ->
         marker = buffer.markPosition([0, 6])
@@ -95,6 +99,10 @@ describe "Marker", ->
 
         expect(buffer.findMarkers({})).toEqual [marker1]
         expect(buffer.getMarkers()).toEqual [marker1]
+
+      it "allows arbitrary properties to be assigned", ->
+        marker = buffer.markPosition([0, 6], foo: 'bar')
+        expect(marker.getProperties()).toEqual({foo: 'bar'})
 
   describe "direct updates", ->
     [marker, changes] = []

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -197,7 +197,9 @@ class MarkerLayer
   # Returns a {Marker}.
   markPosition: (position, options={}) ->
     position = @delegate.clipPosition(position)
-    @markRange(new Range(position, position), {tailed: false, invalidate: options.invalidate})
+    options = Marker.extractParams(options)
+    options.tailed = false
+    @createMarker(@delegate.clipRange(new Range(position, position)), options)
 
   ###
   Section: Event subscription


### PR DESCRIPTION
@lierdakil is there anything else we broke that needs to be restored? Seems like we were still working correctly in `markRange`.