### PR TITLE
Clarify ownership of MarkerLayers

### DIFF
--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -141,12 +141,12 @@ class DisplayLayer
     @notifyObserversIfMarkerScreenPositionsChanged()
 
   addMarkerLayer: (options) ->
-    markerLayer = new DisplayMarkerLayer(this, @buffer.addMarkerLayer(options))
+    markerLayer = new DisplayMarkerLayer(this, @buffer.addMarkerLayer(options), true)
     @displayMarkerLayersById[markerLayer.id] = markerLayer
 
   getMarkerLayer: (id) ->
     if bufferMarkerLayer = @buffer.getMarkerLayer(id)
-      @displayMarkerLayersById[id] ?= new DisplayMarkerLayer(this, bufferMarkerLayer)
+      @displayMarkerLayersById[id] ?= new DisplayMarkerLayer(this, bufferMarkerLayer, false)
 
   notifyObserversIfMarkerScreenPositionsChanged: ->
     for id, displayMarkerLayer of @displayMarkerLayersById


### PR DESCRIPTION
If a DisplayMarkerLayer is created via DisplayLayer.addMarkerLayer, which is the normal case, it owns its underlying buffer MarkerLayer and should destroy it when it is destroyed. However, legacy APIs force us to allow DisplayMarkerLayers to be constructed for existing buffer MarkerLayers, in which case we don’t want them to *own* the underlying MarkerLayer and destroy it when they are destroyed.

Refs atom/atom#12111

/cc @maxbrunsfeld @as-cii 