### PR TITLE
Add more assertions and metadata to investigate invalid decoration iterator position error

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -121,6 +121,7 @@ describe "TextBuffer", ->
         newRange: [[0, 2], [2, 4]]
         oldText: "llo\nworld\r\nhow"
         newText: "y there\r\ncat\nwhat"
+        eventId: 1
       }]
 
     it "notifies ::onDidChange observers with the relevant details after a change", ->
@@ -132,6 +133,7 @@ describe "TextBuffer", ->
         newRange: [[0, 2], [2, 4]]
         oldText: "llo\nworld\r\nhow"
         newText: "y there\r\ncat\nwhat"
+        eventId: 1
       }]
 
     it "returns the newRange of the change", ->

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -899,7 +899,8 @@ class DisplayLayer
             foldCount: @foldsMarkerLayer.getMarkerCount(),
             atomicSoftTabs: @atomicSoftTabs,
             tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId,
-            displayLayerEventId: @lastBufferChangeEventId
+            displayLayerEventId: @lastBufferChangeEventId,
+            tokenizedBufferInvalidRows: @textDecorationLayer.invalidRows
           }
           throw error
 

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -222,6 +222,12 @@ class DisplayLayer
     @emitter.on 'did-change-sync', callback
 
   bufferDidChange: (change) ->
+    @lastBufferChangeEventId = change.eventId
+    global.atom?.assert(
+      @lastBufferChangeEventId is @textDecorationLayer.lastBufferChangeEventId,
+      'Buffer Change Event Ids are different in buffer.onDidChange event handler',
+      (error) => error.metadata = {displayLayerEventId: @lastBufferChangeEventId, tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId}
+    )
     {oldRange, newRange} = @expandChangeRegionToSurroundingEmptyLines(change.oldRange, change.newRange)
 
     {startScreenRow, endScreenRow, startBufferRow, endBufferRow} = @expandBufferRangeToLineBoundaries(oldRange)
@@ -804,6 +810,12 @@ class DisplayLayer
     @getScreenLines().map((screenLine) -> screenLine.lineText).join('\n')
 
   getScreenLines: (startRow=0, endRow=@getScreenLineCount()) ->
+    global.atom?.assert(
+      @lastBufferChangeEventId is @textDecorationLayer.lastBufferChangeEventId,
+      'Buffer Change Event Ids are different in getScreenLines',
+      (error) => error.metadata = {displayLayerEventId: @lastBufferChangeEventId, tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId}
+    )
+
     decorationIterator = @textDecorationLayer.buildIterator()
     screenLines = []
     @spatialLineIterator.seekToScreenRow(startRow)
@@ -865,7 +877,9 @@ class DisplayLayer
             softWrapColumn: @softWrapColumn,
             softWrapHangingIndent: @softWrapHangingIndent,
             foldCount: @foldsMarkerLayer.getMarkerCount(),
-            atomicSoftTabs: @atomicSoftTabs
+            atomicSoftTabs: @atomicSoftTabs,
+            tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId,
+            displayLayerEventId: @lastBufferChangeEventId
           }
           throw error
 

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -864,7 +864,7 @@ class DisplayLayer
             bufferLines[bufferRow] = bufferLine.length
 
           tokenizedLines = []
-          for tokenizedLine, bufferRow in @textDecorationLayer?.tokenizedLines
+          for tokenizedLine, bufferRow in @textDecorationLayer?.tokenizedLines ? []
             if bufferRow - 10 <= bufferStart.row <= bufferRow
               {tags, openScopes} = tokenizedLine
               tokenizedLines[bufferRow] = [tags, openScopes]

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -222,6 +222,17 @@ class DisplayLayer
     @emitter.on 'did-change-sync', callback
 
   bufferDidChange: (change) ->
+    if @lastBufferChangeEventId?
+      global.atom?.assert(
+        @lastBufferChangeEventId is change.eventId - 1,
+        'Buffer Change Event Ids are not sequential',
+        (error) =>
+          error.metadata = {
+            displayLayerEventId: @lastBufferChangeEventId,
+            nextDisplayLayerEventId: change.eventId,
+            tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId
+          }
+      )
     @lastBufferChangeEventId = change.eventId
     global.atom?.assert(
       @lastBufferChangeEventId is @textDecorationLayer.lastBufferChangeEventId,

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -89,6 +89,8 @@ class TextBuffer
   #     after initialization.
   #   * `text` The initial {String} text of the buffer.
   constructor: (params) ->
+    @eventIdCounter = 0
+
     text = params if typeof params is 'string'
 
     @emitter = new Emitter
@@ -728,7 +730,7 @@ class TextBuffer
     normalizedNewText += lastLine
 
     newText = normalizedNewText
-    changeEvent = Object.freeze({oldRange, newRange, oldText, newText})
+    changeEvent = Object.freeze({oldRange, newRange, oldText, newText, eventId: @eventIdCounter++})
     @emitter.emit 'will-change', changeEvent
 
     # Update first and last line so replacement preserves existing prefix and suffix of oldRange


### PR DESCRIPTION
We discovered via #166 that the contents of the display layer seem to be out of sync with the tokenized buffer in some cases. The display layer thinks lines are shorter than they are in the tokenized buffer, which causes the text decoration iterator to lag behind. This PR introduces additional metadata to the reported exceptions to help us debug this error.

Refs https://github.com/atom/atom/issues/12085