### PR TITLE
Copy foldCharacter and atomicSoftTabs in DisplayLayer.prototype.copy()

### DIFF
--- a/spec/display-layer-spec.coffee
+++ b/spec/display-layer-spec.coffee
@@ -11,6 +11,28 @@ describe "DisplayLayer", ->
   beforeEach ->
     jasmine.addCustomEqualityTester(require("underscore-plus").isEqual)
 
+  describe "::copy()", ->
+    it "creates a new DisplayLayer having the same settings", ->
+      buffer = new TextBuffer(text: SAMPLE_TEXT)
+      displayLayer1 = buffer.addDisplayLayer({
+        invisibles: {eol: 'X'}, tabLength: 3, softWrapColumn: 20,
+        softWrapHangingIndent: 2, showIndentGuides: true, foldCharacter: 'Y',
+        atomicSoftTabs: false, ratioForCharacter: (-> 3.0), isWrapBoundary: (-> false)
+      })
+      displayLayer1.foldBufferRange(Range(Point(0, 1), Point(1, 1)))
+      displayLayer2 = displayLayer1.copy()
+      expect(displayLayer2.getText()).toBe(displayLayer1.getText())
+      expect(displayLayer2.foldsMarkerLayer.getMarkers().length).toBe(displayLayer1.foldsMarkerLayer.getMarkers().length)
+      expect(displayLayer2.invisibles).toEqual(displayLayer1.invisibles)
+      expect(displayLayer2.tabLength).toEqual(displayLayer1.tabLength)
+      expect(displayLayer2.softWrapColumn).toEqual(displayLayer1.softWrapColumn)
+      expect(displayLayer2.softWrapHangingIndent).toEqual(displayLayer1.softWrapHangingIndent)
+      expect(displayLayer2.showIndentGuides).toEqual(displayLayer1.showIndentGuides)
+      expect(displayLayer2.foldCharacter).toEqual(displayLayer1.foldCharacter)
+      expect(displayLayer2.atomicSoftTabs).toEqual(displayLayer1.atomicSoftTabs)
+      expect(displayLayer2.ratioForCharacter).toBe(displayLayer1.ratioForCharacter)
+      expect(displayLayer2.isWrapBoundary).toBe(displayLayer1.isWrapBoundary)
+
   describe "hard tabs", ->
     it "expands hard tabs to their tab stops", ->
       buffer = new TextBuffer(text: '\ta\tbc\tdef\tg\n\th')

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -62,7 +62,6 @@ class DisplayLayer
 
   constructor: (@id, @buffer, settings={}) ->
     @displayMarkerLayersById = {}
-    @textDecorationLayer = null
     @foldsMarkerLayer = settings.foldsMarkerLayer ? @buffer.addMarkerLayer({
       maintainHistory: false,
       persistent: true,
@@ -99,8 +98,9 @@ class DisplayLayer
     newId = @buffer.nextDisplayLayerId++
     foldsMarkerLayer = @foldsMarkerLayer.copy()
     copy = new DisplayLayer(newId, @buffer, {
-      foldsMarkerLayer, @tabLength, @invisibles, @showIndentGuides,
-      @softWrapColumn, @softWrapHangingIndent, @ratioForCharacter, @isWrapBoundary
+      foldsMarkerLayer, @invisibles, @tabLength, @softWrapColumn,
+      @softWrapHangingIndent, @showIndentGuides, @ratioForCharacter,
+      @isWrapBoundary, @foldCharacter, @atomicSoftTabs
     })
     @buffer.displayLayers[newId] = copy
 


### PR DESCRIPTION
When adding the `atomicSoftTabs` and `foldCharacter` parameters, we forgot to do so also in `.prototype.copy()`. This could lead to unfortunate behaviors like splitting a pane and have the cursor behave differently depending on which pane the user is working on.

With this pull-request we add the missing settings to `copy()` along with a test that makes sure we don't regress in the future.

/cc: @nathansobo @maxbrunsfeld 