### PR TITLE
Prevent DisplayLayer state from becoming inconsistent with nested did-change event handlers

### DIFF
--- a/spec/helpers/test-decoration-layer.coffee
+++ b/spec/helpers/test-decoration-layer.coffee
@@ -19,7 +19,7 @@ class TestDecorationLayer
       @markerIndex.insert(markerId, Point.fromObject(rangeStart), Point.fromObject(rangeEnd))
       @tagsByMarkerId[markerId] = tag
 
-    @buffer?.preemptDidChange(@bufferDidChange.bind(this))
+    @buffer?.registerTextDecorationLayer(this)
 
   buildIterator: ->
     new TestDecorationLayerIterator(this)

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -5,6 +5,7 @@ temp = require 'temp'
 Random = require 'random-seed'
 Point = require '../src/point'
 Range = require '../src/range'
+DisplayLayer = require '../src/display-layer'
 TextBuffer = require '../src/text-buffer'
 SampleText = fs.readFileSync(join(__dirname, 'fixtures', 'sample.js'), 'utf8')
 
@@ -109,48 +110,68 @@ describe "TextBuffer", ->
       buffer.setTextInRange([[0, 2], [1, 3]], "y\nyou're o", normalizeLineEndings: false)
       expect(buffer.getText()).toEqual "hey\nyou're old\r\nhow are you doing?"
 
-    it "notifies ::onWillChange observers with the relevant details before a change", ->
-      changes = []
-      buffer.onWillChange (change) ->
-        expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
-        changes.push(change)
+    describe "before a change", ->
+      it "notifies ::onWillChange observers with the relevant details", ->
+        changes = []
+        buffer.onWillChange (change) ->
+          expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
+          changes.push(change)
 
-      buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat", normalizeLineEndings: false)
-      expect(changes).toEqual [{
-        oldRange: [[0, 2], [2, 3]]
-        newRange: [[0, 2], [2, 4]]
-        oldText: "llo\nworld\r\nhow"
-        newText: "y there\r\ncat\nwhat"
-        eventId: 1
-      }]
+        buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat", normalizeLineEndings: false)
+        expect(changes).toEqual [{
+          oldRange: [[0, 2], [2, 3]]
+          newRange: [[0, 2], [2, 4]]
+          oldText: "llo\nworld\r\nhow"
+          newText: "y there\r\ncat\nwhat"
+          eventId: 1
+        }]
 
-    it "notifies, in order, registered decoration layers, display layers and ::onDidChange observers with the relevant details after a change", ->
-      events = []
-      textDecorationLayer1 = {bufferDidChange: (e) -> events.push({source: textDecorationLayer1, event: e})}
-      textDecorationLayer2 = {bufferDidChange: (e) -> events.push({source: textDecorationLayer2, event: e})}
-      displayLayer1 = buffer.addDisplayLayer()
-      displayLayer2 = buffer.addDisplayLayer()
-      spyOn(displayLayer1, 'bufferDidChange').and.callFake (e) -> events.push({source: displayLayer1, event: e})
-      spyOn(displayLayer2, 'bufferDidChange').and.callFake (e) -> events.push({source: displayLayer2, event: e})
-      buffer.onDidChange (e) -> events.push({source: buffer, event: e})
-      buffer.registerTextDecorationLayer(textDecorationLayer1)
-      buffer.registerTextDecorationLayer(textDecorationLayer1) # insert a duplicate decoration layer
-      buffer.registerTextDecorationLayer(textDecorationLayer2)
+    describe "after a change", ->
+      it "notifies, in order, decoration layers, display layers, ::onDidChange observers and display layer ::onDidChangeSync observers with the relevant details", ->
+        events = []
+        textDecorationLayer1 = {bufferDidChange: (e) -> events.push({source: textDecorationLayer1, event: e})}
+        textDecorationLayer2 = {bufferDidChange: (e) -> events.push({source: textDecorationLayer2, event: e})}
+        displayLayer1 = buffer.addDisplayLayer()
+        displayLayer2 = buffer.addDisplayLayer()
+        spyOn(displayLayer1, 'bufferDidChange').and.callFake (e) ->
+          events.push({source: displayLayer1, event: e})
+          DisplayLayer.prototype.bufferDidChange.call(displayLayer1, e)
+        spyOn(displayLayer2, 'bufferDidChange').and.callFake (e) ->
+          events.push({source: displayLayer2, event: e})
+          DisplayLayer.prototype.bufferDidChange.call(displayLayer2, e)
+        buffer.onDidChange (e) -> events.push({source: buffer, event: e})
+        buffer.registerTextDecorationLayer(textDecorationLayer1)
+        buffer.registerTextDecorationLayer(textDecorationLayer1) # insert a duplicate decoration layer
+        buffer.registerTextDecorationLayer(textDecorationLayer2)
 
-      buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat", normalizeLineEndings: false)
-      changeEvent = {
-        oldRange: [[0, 2], [2, 3]], newRange: [[0, 2], [2, 4]]
-        oldText: "llo\nworld\r\nhow", newText: "y there\r\ncat\nwhat",
-        eventId: 1
-      }
+        disposable = displayLayer1.onDidChangeSync ->
+          disposable.dispose()
+          buffer.setTextInRange([[1, 1], [1, 2]], "abc", normalizeLineEndings: false)
+        buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat", normalizeLineEndings: false)
 
-      expect(events).toEqual [
-        {source: textDecorationLayer1, event: changeEvent},
-        {source: textDecorationLayer2, event: changeEvent},
-        {source: displayLayer1, event: changeEvent},
-        {source: displayLayer2, event: changeEvent},
-        {source: buffer, event: changeEvent}
-      ]
+        changeEvent1 = {
+          oldRange: [[0, 2], [2, 3]], newRange: [[0, 2], [2, 4]]
+          oldText: "llo\nworld\r\nhow", newText: "y there\r\ncat\nwhat",
+          eventId: 1
+        }
+        changeEvent2 = {
+          oldRange: [[1, 1], [1, 2]], newRange: [[1, 1], [1, 4]]
+          oldText: "a", newText: "abc",
+          eventId: 2
+        }
+        expect(events).toEqual [
+          {source: textDecorationLayer1, event: changeEvent1},
+          {source: textDecorationLayer2, event: changeEvent1},
+          {source: displayLayer1, event: changeEvent1},
+          {source: displayLayer2, event: changeEvent1},
+          {source: buffer, event: changeEvent1},
+
+          {source: textDecorationLayer1, event: changeEvent2},
+          {source: textDecorationLayer2, event: changeEvent2},
+          {source: displayLayer1, event: changeEvent2},
+          {source: displayLayer2, event: changeEvent2},
+          {source: buffer, event: changeEvent2}
+        ]
 
     it "returns the newRange of the change", ->
       expect(buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat"), normalizeLineEndings: false).toEqual [[0, 2], [2, 4]]

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -69,7 +69,6 @@ class DisplayLayer
       destroyInvalidatedMarkers: true
     })
     @foldIdCounter = 1
-    @disposables = @buffer.onDidChange(@bufferDidChange.bind(this))
     @displayIndex = new DisplayIndex
     @spatialTokenIterator = @displayIndex.buildTokenIterator()
     @spatialLineIterator = @displayIndex.buildScreenLineIterator()
@@ -105,7 +104,6 @@ class DisplayLayer
     @buffer.displayLayers[newId] = copy
 
   destroy: ->
-    @disposables.dispose()
     @foldsMarkerLayer.destroy()
     for id, displayMarkerLayer of @displayMarkerLayersById
       displayMarkerLayer.destroy()

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -131,7 +131,7 @@ class DisplayLayer
     oldRowExtent = endScreenRow - startScreenRow
     newRowExtent = newLines.length
     @spliceDisplayIndex(startScreenRow, oldRowExtent, newLines)
-    @emitter.emit 'did-change-sync', Object.freeze([{
+    @emitDidChangeSyncEvent Object.freeze([{
       start: Point(startScreenRow, 0),
       oldExtent: Point(oldRowExtent, 0),
       newExtent: Point(newRowExtent, 0)
@@ -167,7 +167,7 @@ class DisplayLayer
       newScreenLines = @buildSpatialScreenLines(startBufferRow, endBufferRow)
       newRowExtent = newScreenLines.length
       @spliceDisplayIndex(startScreenRow, oldRowExtent, newScreenLines)
-      @emitter.emit 'did-change-sync', Object.freeze([{
+      @emitDidChangeSyncEvent Object.freeze([{
         start: Point(startScreenRow, 0),
         oldExtent: Point(oldRowExtent, 0),
         newExtent: Point(newRowExtent, 0)
@@ -207,7 +207,7 @@ class DisplayLayer
     newScreenLines = @buildSpatialScreenLines(startBufferRow, endBufferRow)
     newRowExtent = newScreenLines.length
     @spliceDisplayIndex(startScreenRow, oldRowExtent, newScreenLines)
-    @emitter.emit 'did-change-sync', Object.freeze([{
+    @emitDidChangeSyncEvent Object.freeze([{
       start: Point(startScreenRow, 0),
       oldExtent: Point(oldRowExtent, 0),
       newExtent: Point(newRowExtent, 0)
@@ -215,6 +215,9 @@ class DisplayLayer
     @notifyObserversIfMarkerScreenPositionsChanged()
 
     foldMarkers.map((marker) -> marker.getRange())
+
+  emitDidChangeSyncEvent: (event) ->
+    @emitter.emit 'did-change-sync', event
 
   onDidChangeSync: (callback) ->
     @emitter.on 'did-change-sync', callback
@@ -265,7 +268,9 @@ class DisplayLayer
         extent = range.getExtent()
         combinedChanges.splice(range.start, extent, extent)
 
-    @emitter.emit 'did-change-sync', Object.freeze(normalizePatchChanges(combinedChanges.getChanges()))
+    # Construct the appropriate `did-change-sync` event and rely on TextBuffer
+    # to dispatch it.
+    Object.freeze(normalizePatchChanges(combinedChanges.getChanges()))
 
   spliceDisplayIndex: (startScreenRow, oldRowExtent, newScreenLines) ->
     deletedSpatialLineIds = @displayIndex.splice(startScreenRow, oldRowExtent, newScreenLines)
@@ -285,7 +290,7 @@ class DisplayLayer
     screenRange = @translateBufferRange(bufferRange)
     @invalidateScreenLines(screenRange)
     extent = screenRange.getExtent()
-    @emitter.emit 'did-change-sync', [{
+    @emitDidChangeSyncEvent [{
       start: screenRange.start,
       oldExtent: extent,
       newExtent: extent

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -765,14 +765,19 @@ class TextBuffer
     @emitDidChangeEvent(changeEvent)
 
   emitDidChangeEvent: (changeEvent) ->
-    # First, emit the event on all the registered text decoration layers.
+    # 1. Emit the change event on all the registered text decoration layers.
     @textDecorationLayers.forEach (textDecorationLayer) ->
       textDecorationLayer.bufferDidChange(changeEvent)
-    # Then, emit it on all the registered display layers.
+    # 2. Emit the change event on all the registered display layers.
+    changeEventsByDisplayLayer = new Map()
     for id, displayLayer of @displayLayers
-      displayLayer.bufferDidChange(changeEvent)
-    # Finally, emit a normal `did-change` event for other subscribers too.
+      event = displayLayer.bufferDidChange(changeEvent)
+      changeEventsByDisplayLayer.set(displayLayer, event)
+    # 3. Emit a normal `did-change` event for other subscribers too.
     @emitter.emit 'did-change', changeEvent
+    # 4. Emit a `did-change-sync` event from all the registered display layers.
+    changeEventsByDisplayLayer.forEach (event, displayLayer) ->
+      displayLayer.emitDidChangeSyncEvent(event)
 
   # Public: Delete the text in the given range.
   #


### PR DESCRIPTION
Refs: atom/atom#12085

After #168, we have observed that sometimes change events are emitted in a order we don't expect. A similar situation could be reproduced by creating a display layer, adding a `onDidChange` handler in `TextBuffer` and then creating a second display layer by calling `copy()` on the first one. If the `onDidChange` handler applies some modification to the text, as soon as an edit is made on the buffer the second display layer will receive change events in a reversed order and, therefore, will splice invalid regions into the display index.

With this pull-request we want to ensure that decoration layers and display layers are always updated in lockstep, thereby preventing them from having an inconsistent state with respect to each other.

Another positive aspect of this change is that it should shield against possible errors happening in third-party `did-change` event handlers that get registered before the display layer event handler. In facts, such errors might cause the change event to not trigger sometimes on the display layer, and thus to throw errors on future updates to the spatial lines index.

For these reasons, we are introducing a `registerTextDecorationLayer` method on `TextBuffer` that needs to be called by decoration layers when they are initialized. Doing so will enforce that change events are emitted first on decoration layers, then on display layers, then on `TextBuffer.onDidChange` subscribers, and finally on `DisplayLayer.onDidChangeSync` subscribers. The `registerTextDecorationLayer` method returns a `Disposable`, which should be called when the decoration layer is destroyed in order to stop receiving updates.

An alternative implementation might have computed all the decoration layers based on the registered display layers on a particular `TextBuffer` instance. This, however, would have been somewhat inconvenient because it would have forced users of `TokenizedBuffer` to always create a `DisplayLayer`, introducing some unnecessary coupling between the two objects.

/cc: @nathansobo 