### PR TITLE
Remove event order assertions

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -123,7 +123,6 @@ describe "TextBuffer", ->
           newRange: [[0, 2], [2, 4]]
           oldText: "llo\nworld\r\nhow"
           newText: "y there\r\ncat\nwhat"
-          eventId: 1
         }]
 
     describe "after a change", ->
@@ -152,12 +151,10 @@ describe "TextBuffer", ->
         changeEvent1 = {
           oldRange: [[0, 2], [2, 3]], newRange: [[0, 2], [2, 4]]
           oldText: "llo\nworld\r\nhow", newText: "y there\r\ncat\nwhat",
-          eventId: 1
         }
         changeEvent2 = {
           oldRange: [[1, 1], [1, 2]], newRange: [[1, 1], [1, 4]]
           oldText: "a", newText: "abc",
-          eventId: 2
         }
         expect(events).toEqual [
           {source: textDecorationLayer1, event: changeEvent1},

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -223,23 +223,6 @@ class DisplayLayer
     @emitter.on 'did-change-sync', callback
 
   bufferDidChange: (change) ->
-    if @lastBufferChangeEventId?
-      global.atom?.assert(
-        @lastBufferChangeEventId is change.eventId - 1,
-        'Buffer Change Event Ids are not sequential',
-        (error) =>
-          error.metadata = {
-            displayLayerEventId: @lastBufferChangeEventId,
-            nextDisplayLayerEventId: change.eventId,
-            tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId
-          }
-      )
-    @lastBufferChangeEventId = change.eventId
-    global.atom?.assert(
-      @lastBufferChangeEventId is @textDecorationLayer.lastBufferChangeEventId,
-      'Buffer Change Event Ids are different in buffer.onDidChange event handler',
-      (error) => error.metadata = {displayLayerEventId: @lastBufferChangeEventId, tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId}
-    )
     {oldRange, newRange} = @expandChangeRegionToSurroundingEmptyLines(change.oldRange, change.newRange)
 
     {startScreenRow, endScreenRow, startBufferRow, endBufferRow} = @expandBufferRangeToLineBoundaries(oldRange)
@@ -824,12 +807,6 @@ class DisplayLayer
     @getScreenLines().map((screenLine) -> screenLine.lineText).join('\n')
 
   getScreenLines: (startRow=0, endRow=@getScreenLineCount()) ->
-    global.atom?.assert(
-      @lastBufferChangeEventId is @textDecorationLayer.lastBufferChangeEventId,
-      'Buffer Change Event Ids are different in getScreenLines',
-      (error) => error.metadata = {displayLayerEventId: @lastBufferChangeEventId, tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId}
-    )
-
     decorationIterator = @textDecorationLayer.buildIterator()
     screenLines = []
     @spatialLineIterator.seekToScreenRow(startRow)
@@ -901,8 +878,6 @@ class DisplayLayer
             softWrapHangingIndent: @softWrapHangingIndent,
             foldCount: @foldsMarkerLayer.getMarkerCount(),
             atomicSoftTabs: @atomicSoftTabs,
-            tokenizedBufferEventId: @textDecorationLayer.lastBufferChangeEventId,
-            displayLayerEventId: @lastBufferChangeEventId,
             tokenizedBufferInvalidRows: @textDecorationLayer.invalidRows
           }
           throw error

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -89,8 +89,6 @@ class TextBuffer
   #     after initialization.
   #   * `text` The initial {String} text of the buffer.
   constructor: (params) ->
-    @eventIdCounter = 0
-
     text = params if typeof params is 'string'
 
     @emitter = new Emitter
@@ -731,7 +729,7 @@ class TextBuffer
     normalizedNewText += lastLine
 
     newText = normalizedNewText
-    changeEvent = Object.freeze({oldRange, newRange, oldText, newText, eventId: @eventIdCounter++})
+    changeEvent = Object.freeze({oldRange, newRange, oldText, newText})
     @emitter.emit 'will-change', changeEvent
 
     # Update first and last line so replacement preserves existing prefix and suffix of oldRange


### PR DESCRIPTION
We are still seeing errors related to the decoration iterator position on Bugsnag, but after #170 we are pretty confident that buffer changes are propagated in the order we expect.