### PR TITLE
Skip close tags with no matching open tag

### DIFF
--- a/spec/display-layer-spec.coffee
+++ b/spec/display-layer-spec.coffee
@@ -830,6 +830,23 @@ describe "DisplayLayer", ->
         {text: '', close: ['following-fold', 'surrounding-fold'], open: []}
       ])
 
+    it "skips close tags with no matching open tag", ->
+      buffer = new TextBuffer(text: 'abcde')
+      displayLayer = buffer.addDisplayLayer()
+      boundaries = [
+        {position: Point(0, 0), closeTags: [], openTags: ['a', 'b']},
+        {position: Point(0, 2), closeTags: ['c'], openTags: []}
+      ]
+      iterator = {
+        getOpenTags: -> boundaries[0].openTags
+        getCloseTags: -> boundaries[0].closeTags
+        getPosition: -> boundaries[0]?.position ? Point.INFINITY
+        moveToSuccessor: -> boundaries.shift()
+        seek: -> []
+      }
+      displayLayer.setTextDecorationLayer({buildIterator: -> iterator})
+      expect(displayLayer.getScreenLines(0, 1)[0].tagCodes).toEqual([-1, -3, 2, -4, -2, -1, -3, 3, -4, -2])
+
     it "emits update events from the display layer when text decoration ranges are invalidated", ->
       buffer = new TextBuffer(text: """
         abc

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -1032,7 +1032,9 @@ class DisplayLayer
             tagsToCloseCounts[mostRecentOpenTag]--
           else
             openTags.unshift(mostRecentOpenTag)
-        closeTags.push(closeTag)
+
+        if mostRecentOpenTag?
+          closeTags.push(closeTag)
 
     openTags.push(tagsToOpen...)
     containingTags.push(tagsToOpen...)


### PR DESCRIPTION
Refs: atom/atom#10350

This pull-request makes the `DisplayLayer` tolerant to text decoration layers that produce invalid tag boundaries. In particular, we will now skip close tags that have unmatched open tags which were previously causing exceptions in our rendering layer. This also prepares us for a future where we open up the decoration layer API to package authors officially. This kind of code is hard to get perfect, so being tolerant here makes sense since it doesn't cost us anything in terms of performance.

Currently, we are the only official consumers of the text decoration layer APIs, but git-plus overrides methods in first-mate, sometimes producing unmatched close tags.