### PR TITLE
Add benchmark for constructing buffers & display layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ node_js:
 env:
   - CC=gcc-4.8 CXX=g++-4.8
 
+script: npm run ci
+
 git:
   depth: 10
 

--- a/benchmarks/construction.js
+++ b/benchmarks/construction.js
@@ -1,0 +1,45 @@
+const regression = require('regression')
+const helpers = require('./helpers')
+const TextBuffer = require('..')
+
+const TRIAL_COUNT = 3
+const SIZES_IN_KB = [
+  1,
+  10,
+  100,
+  1000,
+  10000,
+]
+
+const bufferTimesInMS = []
+const displayLayerTimesInMS = []
+
+for (let sizeInKB of SIZES_IN_KB) {
+  let text = helpers.getRandomText(sizeInKB)
+  let buffer = new TextBuffer({text})
+
+  let t0 = Date.now()
+  for (let i = 0; i < TRIAL_COUNT; i++) {
+    new TextBuffer({text})
+  }
+
+  let t1 = Date.now()
+  for (let i = 0; i < TRIAL_COUNT; i++) {
+    buffer.addDisplayLayer({})
+  }
+
+  let t2 = Date.now()
+  bufferTimesInMS.push((t1 - t0) / TRIAL_COUNT)
+  displayLayerTimesInMS.push((t2 - t1) / TRIAL_COUNT)
+}
+
+function getMillisecondsPerMegabyte(timesInMS) {
+  const series = timesInMS.map((time, i) => [SIZES_IN_KB[i], time * 1024])
+  const slownessRegression = regression('linear', series)
+  return slownessRegression.equation[0]
+}
+
+console.log('Construction')
+console.log('------------')
+console.log('TextBuffer:    %s ms/MB', getMillisecondsPerMegabyte(bufferTimesInMS).toFixed(1))
+console.log('DisplayLayer:  %s ms/MB', getMillisecondsPerMegabyte(displayLayerTimesInMS).toFixed(1))

--- a/benchmarks/construction.js
+++ b/benchmarks/construction.js
@@ -20,12 +20,14 @@ for (let sizeInKB of SIZES_IN_KB) {
 
   let t0 = Date.now()
   for (let i = 0; i < TRIAL_COUNT; i++) {
-    new TextBuffer({text})
+    buffer = new TextBuffer({text})
+    buffer.getTextInRange([[0, 0], [50, 0]])
   }
 
   let t1 = Date.now()
   for (let i = 0; i < TRIAL_COUNT; i++) {
-    buffer.addDisplayLayer({})
+    let displayLayer = buffer.addDisplayLayer({})
+    displayLayer.getScreenLines(0, 50)
   }
 
   let t2 = Date.now()

--- a/benchmarks/helpers.js
+++ b/benchmarks/helpers.js
@@ -1,0 +1,43 @@
+const WORDS = require('../spec/helpers/words')
+const Random = require('random-seed')
+const random = new Random(Date.now())
+
+exports.getRandomText = function (sizeInKB) {
+  const goalLength = sizeInKB * 1024
+
+  let length = 0
+  let lines = []
+  let currentLine = ''
+  let lastLineStartIndex = 0
+  let goalLineLength = random(100)
+
+  for (;;) {
+    if (currentLine.length >= goalLineLength) {
+      length++
+      lines.push(currentLine)
+      if (length >= goalLength) break
+
+      currentLine = ''
+      goalLineLength = random(100)
+    }
+
+    let choice = random(10)
+    if (choice < 2) {
+      length++
+      currentLine += '\t'
+    } else if (choice < 4) {
+      length++
+      currentLine += ' '
+    } else {
+      if (currentLine.length > 0 && !/\s$/.test(currentLine)) {
+        length++
+        currentLine += ' '
+      }
+      word = WORDS[random(WORDS.length)]
+      length += word.length
+      currentLine += word
+    }
+  }
+
+  return lines.join('\n') + '\n'
+}

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('./construction')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "compile": "coffee --no-header --output lib --compile src",
     "lint": "coffeelint -r src spec && eslint src spec",
     "test": "jasmine --captureExceptions --forceexit",
-    "ci": "npm run compile && npm run lint && npm run test"
+    "ci": "npm run compile && npm run lint && npm run test && npm run bench",
+    "bench": "node benchmarks/index"
   },
   "repository": {
     "type": "git",
@@ -42,9 +43,9 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
+    "atom-patch": "0.3.0",
     "delegato": "^1.0.0",
     "diff": "^2.2.1",
-    "atom-patch": "0.3.0",
     "display-index": "^0.1.0",
     "emissary": "^1.0.0",
     "event-kit": "^2.1.0",
@@ -53,6 +54,7 @@
     "line-length-index": "0.0.2",
     "marker-index": "4.0.1",
     "pathwatcher": "6.7.1",
+    "regression": "^1.2.1",
     "serializable": "^1.0.3",
     "span-skip-list": "~0.2.0",
     "underscore-plus": "^1.0.0"


### PR DESCRIPTION
This adds a simple benchmark for constructing buffers and display layers based on different-sized files. The benchmarks are run in CI; I'm not sure if their output is interesting (because the conditions of CI vary so much), but this ensures that they don't bitrot.

```sh
$ npm run bench

Construction
------------
TextBuffer:    53.2 ms/MB
DisplayLayer:  268.1 ms/MB
```

/cc @lee-dohm