### PR TITLE
Avoid computing spatial screen lines until they are needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.3.1-3",
+  "version": "9.3.1-4",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.3.1-2",
+  "version": "9.3.1-3",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.3.1-0",
+  "version": "9.3.1-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.3.1-1",
+  "version": "9.3.1-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.3.0",
+  "version": "9.3.1-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/display-layer-spec.coffee
+++ b/spec/display-layer-spec.coffee
@@ -40,7 +40,7 @@ describe "DisplayLayer", ->
 
       expect(displayLayer.getText()).toBe('    a   bc  def g\n    h')
 
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: '    ', close: [], open: ["hard-tab leading-whitespace"]},
         {text: 'a', close: ["hard-tab leading-whitespace"], open: []},
         {text: '   ', close: [], open: ["hard-tab"]},
@@ -89,7 +89,7 @@ describe "DisplayLayer", ->
 
       expect(displayLayer.getText()).toBe('••••••••••a\n•••••\n••  ••••    ••')
 
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: '••••', close: [], open: ["invisible-character leading-whitespace"]},
         {text: '••••', close: ["invisible-character leading-whitespace"], open: ["invisible-character leading-whitespace"]},
         {text: '••', close: ["invisible-character leading-whitespace"], open: ["invisible-character leading-whitespace"]},
@@ -362,7 +362,7 @@ describe "DisplayLayer", ->
       buffer = new TextBuffer(text: '     abc de fgh ijk\n  lmnopqrst')
       displayLayer = buffer.addDisplayLayer(softWrapColumn: 9, showIndentGuides: true, tabLength: 2, invisibles: {space: '•'})
       expect(JSON.stringify(displayLayer.getText())).toBe JSON.stringify('•••••abc \n     de \n     fgh \n     ijk\n••lmnopqr\n  st')
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {close: [], open: ['invisible-character leading-whitespace indent-guide'], text: '••'},
         {close: ['invisible-character leading-whitespace indent-guide'], open: ['invisible-character leading-whitespace indent-guide'], text: '••'},
         {close: ['invisible-character leading-whitespace indent-guide'], open: ['invisible-character leading-whitespace indent-guide'], text: '•'},
@@ -476,7 +476,7 @@ describe "DisplayLayer", ->
       buffer = new TextBuffer(text: '  abc                     ')
       displayLayer = buffer.addDisplayLayer(softWrapColumn: 10)
       expect(JSON.stringify(displayLayer.getText())).toBe JSON.stringify('  abc     \n          \n          ')
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: '  ', close: [], open: ['leading-whitespace']},
         {text: 'abc', close: ['leading-whitespace'], open: []},
         {text: '     ', close: [], open: ['trailing-whitespace']},
@@ -514,7 +514,7 @@ describe "DisplayLayer", ->
         •   •e
       """)
 
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'az', close: [], open: []},
         {text: '••', close: [], open: ["invisible-character leading-whitespace"]},
         {text: 'b c', close: ["invisible-character leading-whitespace"], open: []},
@@ -531,7 +531,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({tabLength: 4, invisibles: {space: '•'}})
 
       expect(displayLayer.getText()).toEqual("abcd\n•••••••\nefgh   jkl\nmno  pqr•••\nst  uvw••   ••")
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'abcd', close: [], open: []},
         {text: '••••', close: [], open: ["invisible-character trailing-whitespace"]},
         {text: '•••', close: ["invisible-character trailing-whitespace"], open: ["invisible-character trailing-whitespace"]},
@@ -552,7 +552,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({tabLength: 4})
 
       expect(displayLayer.getText()).toEqual("     a  b    \n  ")
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: ' ', close: [], open: ["leading-whitespace"]},
         {text: '   ', close: ["leading-whitespace"], open: ["hard-tab leading-whitespace"]},
         {text: ' ', close: ["hard-tab leading-whitespace"], open: ["leading-whitespace"]},
@@ -575,7 +575,7 @@ describe "DisplayLayer", ->
       displayLayer.foldBufferRange([[2, 4], [3, 0]])
       expect(displayLayer.getText()).toBe("••⋯••\n••⋯••⋯d")
 
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: '••', close: [], open: ["invisible-character leading-whitespace"]},
         {text: '⋯', close: ["invisible-character leading-whitespace"], open: ["fold-marker"]},
         {text: '••', close: ["fold-marker"], open: ["invisible-character trailing-whitespace"]},
@@ -592,7 +592,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({tabLength: 4, invisibles: {tab: '»', space: '•'}})
 
       expect(displayLayer.getText()).toBe("a»  b»  \n•»  •d••»   ••")
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'a', close: [], open: []},
         {text: '»  ', close: [], open: ["invisible-character hard-tab"]},
         {text: 'b', close: ["invisible-character hard-tab"], open: []},
@@ -613,7 +613,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({tabLength: 4, invisibles: {cr: '¤', eol: '¬'}})
 
       expect(displayLayer.getText()).toBe("a¬\nb¬\n¬\nd e f¤¬\ngh¤\nij¬\n¤¬\n")
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'a', close: [], open: []},
         {text: '¬', close: [], open: ["invisible-character eol"]},
         {text: '', close: ["invisible-character eol"], open: []},
@@ -652,7 +652,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({showIndentGuides: true, tabLength: 4})
 
       expect(displayLayer.getText()).toBe("         a            \n         b\n        ")
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: '    ', close: [], open: ["leading-whitespace indent-guide"]},
         {text: '    ', close: ["leading-whitespace indent-guide"], open: ["leading-whitespace indent-guide"]},
         {text: ' ', close: ["leading-whitespace indent-guide"], open: ["leading-whitespace indent-guide"]},
@@ -677,7 +677,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({showIndentGuides: true, tabLength: 4, invisibles: {eol: '¬'}})
 
       expect(displayLayer.getText()).toBe("¬         \n¬         \n          a¬\n¬         \n         b¬\n¬        \n¬        \n         ")
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: '', close: [], open: []},
         {text: '¬', close: [], open: ["invisible-character eol indent-guide"]},
         {text: '   ', close: ["invisible-character eol indent-guide"], open: []},
@@ -753,7 +753,7 @@ describe "DisplayLayer", ->
       displayLayer = buffer.addDisplayLayer({showIndentGuides: true, tabLength: 4})
 
       expect(JSON.stringify(displayLayer.getText())).toBe(JSON.stringify("a\n\nb\n  c\n  \n  "))
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'a', close: [], open: []},
         {text: '', close: [], open: []},
         {text: 'b', close: [], open: []},
@@ -784,7 +784,7 @@ describe "DisplayLayer", ->
         ['ae', [[2, 3], [2, 5]]]
       ]))
 
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'a', close: [], open: []},
         {text: 'b', close: [], open: ['aa']},
         {text: 'c', close: [], open: ['ab']},
@@ -820,7 +820,7 @@ describe "DisplayLayer", ->
         ['surrounding-fold', [[0, 1], [2, 5]]]
       ]))
 
-      expectTokens(displayLayer, [
+      expectTokenBoundaries(displayLayer, [
         {text: 'a', close: [], open: []},
         {text: 'b', close: [], open: ['preceding-fold', 'ending-at-fold-start', 'overlapping-fold-start', 'surrounding-fold']},
         {text: 'c', close: ['surrounding-fold', 'overlapping-fold-start', 'ending-at-fold-start', 'preceding-fold'], open: ['ending-at-fold-start', 'overlapping-fold-start', 'surrounding-fold']},
@@ -879,7 +879,7 @@ describe "DisplayLayer", ->
 
       exception = null
       try
-        getTokenLines(displayLayer)
+        getTokenBoundaries(displayLayer)
       catch e
         exception = e
 
@@ -1082,7 +1082,7 @@ verifyChangeEvent = (displayLayer, fn) ->
   # in parts of the buffer that the display layer has not yet indexed.
   displayLayerCopy = displayLayer.copy()
   displayLayerCopy.setTextDecorationLayer(displayLayer.getTextDecorationLayer())
-  previousTokenLines = getTokenLines(displayLayerCopy)
+  previousTokenLines = getTokens(displayLayerCopy)
   displayLayerCopy.destroy()
 
   lastChanges = null
@@ -1092,8 +1092,8 @@ verifyChangeEvent = (displayLayer, fn) ->
 
   displayLayerCopy = displayLayer.copy()
   displayLayerCopy.setTextDecorationLayer(displayLayer.getTextDecorationLayer())
+  expectedTokenLines = getTokens(displayLayerCopy)
   updateTokenLines(previousTokenLines, displayLayerCopy, lastChanges)
-  expectedTokenLines = getTokenLines(displayLayerCopy)
   displayLayerCopy.destroy()
 
   # {diffString} = require 'json-diff'
@@ -1113,7 +1113,7 @@ verifyText = (random, displayLayer, freshDisplayLayer) ->
 verifyTokenConsistency = (random, displayLayer) ->
   containingTags = []
 
-  for tokens in getTokenLines(displayLayer, 0, getRandomScreenRowCount(random, displayLayer))
+  for tokens in getTokenBoundaries(displayLayer, 0, getRandomScreenRowCount(random, displayLayer))
     for {closeTags, openTags, text} in tokens
       for tag in closeTags
         mostRecentOpenTag = containingTags.pop()
@@ -1246,8 +1246,8 @@ expectPositionTranslations = (displayLayer, tranlations) ->
       expect(displayLayer.translateScreenPosition(screenPosition)).toEqual(bufferPosition)
       expect(displayLayer.translateBufferPosition(bufferPosition)).toEqual(screenPosition)
 
-expectTokens = (displayLayer, expectedTokens) ->
-  tokenLines = getTokenLines(displayLayer)
+expectTokenBoundaries = (displayLayer, expectedTokens) ->
+  tokenLines = getTokenBoundaries(displayLayer)
   for tokens, screenRow in tokenLines
     screenColumn = 0
     for token in tokens
@@ -1258,7 +1258,17 @@ expectTokens = (displayLayer, expectedTokens) ->
       expect(token.openTags).toEqual(open, "Open tags of token with start position: #{Point(screenRow, screenColumn)}")
       screenColumn += token.text.length
 
-getTokenLines = (displayLayer, startRow=0, endRow=displayLayer.getScreenLineCount()) ->
+getTokens = (displayLayer, startRow=0, endRow=displayLayer.getScreenLineCount()) ->
+  containingTags = []
+  for line in getTokenBoundaries(displayLayer, startRow, endRow)
+    for {closeTags, openTags, text} in line
+      for closeTag in closeTags
+        containingTags.pop()
+      for openTag in openTags
+        containingTags.push(openTag)
+      {tags: containingTags.slice().sort(), text}
+
+getTokenBoundaries = (displayLayer, startRow=0, endRow=displayLayer.getScreenLineCount()) ->
   tokenLines = []
   for {lineText, tagCodes} in displayLayer.getScreenLines(startRow, endRow)
     tokens = []
@@ -1284,11 +1294,12 @@ getTokenLines = (displayLayer, startRow=0, endRow=displayLayer.getScreenLineCoun
 
 updateTokenLines = (tokenLines, displayLayer, changes) ->
   for {start, oldExtent, newExtent} in changes ? []
-    tokenLines.splice(start.row, oldExtent.row, getTokenLines(displayLayer, start.row, start.row + newExtent.row)...)
+    newTokenLines = getTokens(displayLayer, start.row, start.row + newExtent.row)
+    tokenLines.splice(start.row, oldExtent.row, newTokenLines...)
 
 logTokens = (displayLayer) ->
-  s = 'expectTokens(displayLayer, [\n'
-  for tokens in getTokenLines(displayLayer)
+  s = 'expectTokenBoundaries(displayLayer, [\n'
+  for tokens in getTokenBoundaries(displayLayer)
     for {text, closeTags, openTags} in tokens
       s += "  {text: '#{text}', close: #{JSON.stringify(closeTags)}, open: #{JSON.stringify(openTags)}},\n"
   s += '])'

--- a/spec/display-layer-spec.coffee
+++ b/spec/display-layer-spec.coffee
@@ -992,6 +992,20 @@ describe "DisplayLayer", ->
         expect(displayLayer.indexedBufferRowCount).toBe(4)
         expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(2, 11))
 
+    describe "doBackgroundWork(deadline)", ->
+      fakeDeadline = (timeRemaining) -> {timeRemaining: -> timeRemaining--}
+
+      it "computes additional screen lines, returning true or false", ->
+        buffer = new TextBuffer({text: "yo\n".repeat(100)})
+        displayLayer = buffer.addDisplayLayer({})
+
+        expect(displayLayer.doBackgroundWork(fakeDeadline(11))).toBe true
+        expect(displayLayer.indexedBufferRowCount).toBeGreaterThan 0
+        expect(displayLayer.indexedBufferRowCount).toBeLessThan buffer.getLineCount()
+
+        expect(displayLayer.doBackgroundWork(fakeDeadline(1000))).toBe false
+        expect(displayLayer.indexedBufferRowCount).toBe buffer.getLineCount()
+
   now = Date.now()
   for i in [0...100] by 1
     do ->

--- a/spec/display-layer-spec.coffee
+++ b/spec/display-layer-spec.coffee
@@ -931,80 +931,85 @@ describe "DisplayLayer", ->
       expect(displayLayer.translateBufferPosition([1, 8], clipDirection: 'closest')).toEqual [0, 8]
       expect(displayLayer.translateBufferPosition([1, 8], clipDirection: 'forward')).toEqual [0, 8]
 
-  describe "approximate screen dimensions APIs", ->
-    describe "getApproximateScreenLineCount()", ->
-      it "estimates the screen line count based on the currently-indexed portion of the buffer", ->
-        buffer = new TextBuffer({
-          text: """
-            111 111
-            222 222
-            3
-            4
-            5
-            6
-            7
-            8
-          """
-        })
+  describe ".getApproximateScreenLineCount()", ->
+    it "estimates the screen line count based on the currently-indexed portion of the buffer", ->
+      buffer = new TextBuffer({
+        text: """
+          111 111
+          222 222
+          3
+          4
+          5
+          6
+          7
+          8
+        """
+      })
 
-        displayLayer = buffer.addDisplayLayer({softWrapColumn: 4})
+      displayLayer = buffer.addDisplayLayer({softWrapColumn: 4})
 
-        # Before indexing any buffer lines, assume that on average, each buffer
-        # line produces one screen line.
-        expect(displayLayer.getApproximateScreenLineCount()).toEqual(buffer.getLineCount())
+      # Before indexing any buffer lines, assume that on average, each buffer
+      # line produces one screen line.
+      expect(displayLayer.getApproximateScreenLineCount()).toEqual(buffer.getLineCount())
 
-        # Index the first two buffer lines, which map to four screen lines.
-        # Assume that on average, each buffer line produces two screen lines.
-        expect(displayLayer.translateBufferPosition(Point(0, Infinity))).toEqual(Point(1, 3))
-        expect(displayLayer.indexedBufferRowCount).toBe(2)
-        expect(displayLayer.getApproximateScreenLineCount()).toEqual(buffer.getLineCount() * 4 / 2)
+      # Index the first two buffer lines, which map to four screen lines.
+      # Assume that on average, each buffer line produces two screen lines.
+      expect(displayLayer.translateBufferPosition(Point(0, Infinity))).toEqual(Point(1, 3))
+      expect(displayLayer.indexedBufferRowCount).toBe(2)
+      expect(displayLayer.getApproximateScreenLineCount()).toEqual(buffer.getLineCount() * 4 / 2)
 
-        # Index the first four buffer lines, which map to six screen lines.
-        # Assume that on average, each buffer line produces two screen lines.
-        # console.log displayLayer.getText()
-        expect(displayLayer.translateBufferPosition(Point(2, 1))).toEqual(Point(4, 1))
-        expect(displayLayer.indexedBufferRowCount).toBe(4)
-        expect(displayLayer.getApproximateScreenLineCount()).toEqual(buffer.getLineCount() * 6 / 4)
+      # Index the first four buffer lines, which map to six screen lines.
+      # Assume that on average, each buffer line produces two screen lines.
+      # console.log displayLayer.getText()
+      expect(displayLayer.translateBufferPosition(Point(2, 1))).toEqual(Point(4, 1))
+      expect(displayLayer.indexedBufferRowCount).toBe(4)
+      expect(displayLayer.getApproximateScreenLineCount()).toEqual(buffer.getLineCount() * 6 / 4)
 
-    describe "getApproximateRightmostScreenPosition()", ->
-      it "returns the rightmost screen position that has been indexed so far", ->
-        buffer = new TextBuffer({
-          text: """
-            111
-            222 222
-            333 333 333
-            444 444
-          """
-        })
+  describe ".getApproximateRightmostScreenPosition()", ->
+    it "returns the rightmost screen position that has been indexed so far", ->
+      buffer = new TextBuffer({
+        text: """
+          111
+          222 222
+          333 333 333
+          444 444
+        """
+      })
 
-        displayLayer = buffer.addDisplayLayer({})
-        expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point.ZERO)
+      displayLayer = buffer.addDisplayLayer({})
+      expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point.ZERO)
 
-        displayLayer.translateBufferPosition(Point(0, 0))
-        expect(displayLayer.indexedBufferRowCount).toBe(2)
-        expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(1, 7))
+      displayLayer.translateBufferPosition(Point(0, 0))
+      expect(displayLayer.indexedBufferRowCount).toBe(2)
+      expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(1, 7))
 
-        displayLayer.translateBufferPosition(Point(1, 0))
-        expect(displayLayer.indexedBufferRowCount).toBe(3)
-        expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(2, 11))
+      displayLayer.translateBufferPosition(Point(1, 0))
+      expect(displayLayer.indexedBufferRowCount).toBe(3)
+      expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(2, 11))
 
-        displayLayer.translateBufferPosition(Point(2, 0))
-        expect(displayLayer.indexedBufferRowCount).toBe(4)
-        expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(2, 11))
+      displayLayer.translateBufferPosition(Point(2, 0))
+      expect(displayLayer.indexedBufferRowCount).toBe(4)
+      expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(2, 11))
 
-    describe "doBackgroundWork(deadline)", ->
-      fakeDeadline = (timeRemaining) -> {timeRemaining: -> timeRemaining--}
+  describe ".doBackgroundWork(deadline)", ->
+    fakeDeadline = (timeRemaining) -> {timeRemaining: -> timeRemaining--}
 
-      it "computes additional screen lines, returning true or false", ->
-        buffer = new TextBuffer({text: "yo\n".repeat(100)})
-        displayLayer = buffer.addDisplayLayer({})
+    it "computes additional screen lines, returning true or false", ->
+      buffer = new TextBuffer({text: "yo\n".repeat(100)})
+      displayLayer = buffer.addDisplayLayer({})
 
-        expect(displayLayer.doBackgroundWork(fakeDeadline(11))).toBe true
-        expect(displayLayer.indexedBufferRowCount).toBeGreaterThan 0
-        expect(displayLayer.indexedBufferRowCount).toBeLessThan buffer.getLineCount()
+      expect(displayLayer.doBackgroundWork(fakeDeadline(11))).toBe true
+      expect(displayLayer.indexedBufferRowCount).toBeGreaterThan 0
+      expect(displayLayer.indexedBufferRowCount).toBeLessThan buffer.getLineCount()
 
-        expect(displayLayer.doBackgroundWork(fakeDeadline(1000))).toBe false
-        expect(displayLayer.indexedBufferRowCount).toBe buffer.getLineCount()
+      expect(displayLayer.doBackgroundWork(fakeDeadline(1000))).toBe false
+      expect(displayLayer.indexedBufferRowCount).toBe buffer.getLineCount()
+
+  describe ".getScreenLines(startRow, endRow)", ->
+    it "returns an empty array when the given start row is greater than the screen line count", ->
+      buffer = new TextBuffer(text: 'hello')
+      displayLayer = buffer.addDisplayLayer({})
+      expect(displayLayer.getScreenLines(1, 2)).toEqual([])
 
   now = Date.now()
   for i in [0...100] by 1

--- a/spec/helpers/test-decoration-layer.coffee
+++ b/spec/helpers/test-decoration-layer.coffee
@@ -49,7 +49,7 @@ class TestDecorationLayer
     @invalidatedRanges ?= []
     for i in [0..@random(5)]
       markerId = @nextMarkerId++
-      tag = WORDS[@random(WORDS.length)]
+      tag = String.fromCharCode('a'.charCodeAt(0) + @random(27))
       @tagsByMarkerId[markerId] = tag
       range = @getRandomRangeCloseTo(oldRange.union(newRange))
       @markerIndex.insert(markerId, range.start, range.end)

--- a/spec/helpers/test-decoration-layer.coffee
+++ b/spec/helpers/test-decoration-layer.coffee
@@ -43,25 +43,37 @@ class TestDecorationLayer
     overlap.forEach (id) => @invalidatedRanges.push(@markerIndex.getRange(id))
     inside.forEach (id) => @invalidatedRanges.push(@markerIndex.getRange(id))
 
-    @insertRandomDecorations()
+    @insertRandomDecorations(oldRange, newRange)
 
-  insertRandomDecorations: ->
+  insertRandomDecorations: (oldRange, newRange) ->
     @invalidatedRanges ?= []
     for i in [0..@random(5)]
       markerId = @nextMarkerId++
       tag = WORDS[@random(WORDS.length)]
       @tagsByMarkerId[markerId] = tag
-      range = @getRandomRange()
+      range = @getRandomRangeCloseTo(oldRange.union(newRange))
       @markerIndex.insert(markerId, range.start, range.end)
       @invalidatedRanges.push(range)
 
-  getRandomRange: ->
-    Range(@getRandomPoint(), @getRandomPoint())
+  getRandomRangeCloseTo: (range) ->
+    if @random(10) < 7
+      minRow = @constrainRow(range.start.row + @random.intBetween(-20, 20))
+    else
+      minRow = 0
 
-  getRandomPoint: ->
-    row = @random(@buffer.getLineCount())
-    column = @random(@buffer.lineForRow(row).length + 1)
-    Point(row, column)
+    if @random(10) < 7
+      maxRow = @constrainRow(range.end.row + @random.intBetween(-20, 20))
+    else
+      maxRow = @buffer.getLastRow()
+
+    startRow = @random.intBetween(minRow, maxRow)
+    endRow = @random.intBetween(startRow, maxRow)
+    startColumn = @random(@buffer.lineForRow(startRow).length + 1)
+    endColumn = @random(@buffer.lineForRow(endRow).length + 1)
+    Range(Point(startRow, startColumn), Point(endRow, endColumn))
+
+  constrainRow: (row) ->
+    Math.max(0, Math.min(@buffer.getLastRow(), row))
 
 class TestDecorationLayerIterator
   constructor: (@layer) ->

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -132,6 +132,7 @@ class DisplayLayer
     @displayIndex.splice(0, Infinity, [])
 
     @emitter.emit('did-reset')
+    @notifyObserversIfMarkerScreenPositionsChanged()
 
   addMarkerLayer: (options) ->
     markerLayer = new DisplayMarkerLayer(this, @buffer.addMarkerLayer(options), true)

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -855,7 +855,7 @@ class DisplayLayer
     decorationIterator = @textDecorationLayer.buildIterator()
     screenLines = []
     @computeSpatialScreenLinesThroughScreenRow(endRow)
-    @spatialLineIterator.seekToScreenRow(startRow)
+    return screenLines unless @spatialLineIterator.seekToScreenRow(startRow)
     containingTags = decorationIterator.seek(@spatialLineIterator.getBufferStart())
     previousLineWasCached = false
 

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -223,8 +223,8 @@ class DisplayLayer
     @emitter.on 'did-reset', callback
 
   bufferWillChange: (change) ->
-    @processingBufferChange = true
     @computeSpatialScreenLinesThroughBufferRow(change.oldRange.end.row)
+    @processingBufferChange = true
 
   bufferDidChange: (change) ->
     {oldRange, newRange} = @expandChangeRegionToSurroundingEmptyLines(change.oldRange, change.newRange)

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -226,8 +226,9 @@ class DisplayLayer
     @emitter.on 'did-reset', callback
 
   bufferWillChange: (change) ->
-    change = @expandChangeRegionToSurroundingEmptyLines(change)
-    @computeSpatialScreenLinesThroughBufferRow(change.oldRange.end.row + 1)
+    endRow = change.oldRange.end.row
+    endRow++ while @buffer.lineForRow(endRow + 1)?.length is 0
+    @computeSpatialScreenLinesThroughBufferRow(endRow)
     @bufferChangeBeingProcessed = change
 
   bufferDidChange: ->

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -1230,3 +1230,12 @@ class DisplayLayer
   lineLengthForScreenRow: (screenRow) ->
     @computeSpatialScreenLinesThroughScreenRow(screenRow)
     @displayIndex.lineLengthForScreenRow(screenRow) or 0
+
+  getApproximateScreenLineCount: ->
+    if @indexedBufferRowCount > 0
+      @buffer.getLineCount() * @displayIndex.getScreenLineCount() / @indexedBufferRowCount
+    else
+      @buffer.getLineCount()
+
+  getApproximateRightmostScreenPosition: ->
+    @displayIndex.getScreenPositionWithMaxLineLength() or Point.ZERO

--- a/src/display-layer.coffee
+++ b/src/display-layer.coffee
@@ -79,6 +79,7 @@ class DisplayLayer
     @tagsByCode = new Map
     @nextOpenTagCode = -1
     @indexedBufferRowCount = 0
+    @processingBufferChange = false
     @reset({
       invisibles: settings.invisibles ? {}
       tabLength: settings.tabLength ? 4
@@ -220,6 +221,10 @@ class DisplayLayer
   onDidReset: (callback) ->
     @emitter.on 'did-reset', callback
 
+  bufferWillChange: (change) ->
+    @processingBufferChange = true
+    @computeSpatialScreenLinesThroughBufferRow(change.oldRange.end.row)
+
   bufferDidChange: (change) ->
     {oldRange, newRange} = @expandChangeRegionToSurroundingEmptyLines(change.oldRange, change.newRange)
 
@@ -231,6 +236,7 @@ class DisplayLayer
     newRowExtent = spatialScreenLines.length
     @spliceDisplayIndex(startScreenRow, oldRowExtent, spatialScreenLines)
     @indexedBufferRowCount += change.newRange.end.row - change.oldRange.end.row
+    @processingBufferChange = false
 
     start = Point(startScreenRow, 0)
     oldExtent = Point(oldRowExtent, 0)

--- a/src/display-marker.coffee
+++ b/src/display-marker.coffee
@@ -381,6 +381,7 @@ class DisplayMarker
     @toString()
 
   notifyObservers: (textChanged) ->
+    return unless @hasChangeObservers
     textChanged ?= false
 
     newHeadBufferPosition = @getHeadBufferPosition()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -730,6 +730,8 @@ class TextBuffer
 
     newText = normalizedNewText
     changeEvent = Object.freeze({oldRange, newRange, oldText, newText})
+    for id, displayLayer of @displayLayers
+      displayLayer.bufferWillChange(changeEvent)
     @emitter.emit 'will-change', changeEvent
 
     # Update first and last line so replacement preserves existing prefix and suffix of oldRange


### PR DESCRIPTION
Previously, creating a `DisplayLayer` would take an amount of time proportional to the size of the underlying buffer, because all of the screen lines were computed immediately.

Now, the `DisplayLayer` waits to compute *any* screen lines until they are needed for some query (e.g. `getScreenLines` or `translateBufferPosition`) or to interpret a buffer change event. This way, `TextBuffer.addDisplayLayer()` is a constant-time operation.

There is also a new method, `DisplayLayer.doBackgroundWork(deadline)`, which can be used to compute additional screen lines in advance of any query that would demand them.

* [x] Defer computation of spatial screen lines until they are needed for individual queries.
* [x] Update randomized tests to make sure that they cover the case where the buffer changes in a region for which spatial screen lines have not yet been computed.
* [x] Add a new public method `DisplayLayer::doBackgroundWork(deadline)` that the TextEditor can call in an idle callback to compute additional spatial screen lines ahead of time.