### PR TITLE
Use native BufferOffsetIndex to map character indices to 2d coordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ node_js:
 env:
   - CC=gcc-4.8 CXX=g++-4.8
 
+before_install:
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y
+  - export PATH=$PATH:$HOME/.cargo/bin
+
 script: npm run ci
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ addons:
     packages:
     - g++-4.8
 
-node_js:
-  - "node"
+node_js: "6"
 
 env:
   - CC=gcc-4.8 CXX=g++-4.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - ps: Start-FileDownload "https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe"
+  - rustup-init.exe -y
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - npm install
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 environment:
   nodejs_version: "6"
 
+platform: x64
+
+image: Visual Studio 2015
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - ps: Start-FileDownload "https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe"
@@ -14,3 +18,6 @@ test_script:
   - npm run ci
 
 build: off
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,11 @@
-environment:
-  nodejs_version: "6"
+image: Visual Studio 2015
 
 platform: x64
 
-image: Visual Studio 2015
-
 install:
-  - ps: Install-Product node $env:nodejs_version
-  - ps: Start-FileDownload "https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe"
-  - rustup-init.exe -y
+  - ps: Install-Product node 6 x86
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe -y --default-toolchain stable-i686-pc-windows-msvc
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - npm install
 
@@ -18,6 +15,3 @@ test_script:
   - npm run ci
 
 build: off
-
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pathwatcher": "6.7.1",
     "regression": "^1.2.1",
     "serializable": "^1.0.3",
-    "superstring": "0.0.5",
+    "superstring": "0.0.6",
     "underscore-plus": "^1.0.0"
   },
   "coffeelintConfig": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pathwatcher": "6.7.1",
     "regression": "^1.2.1",
     "serializable": "^1.0.3",
-    "superstring": "0.0.3",
+    "superstring": "0.0.4",
     "underscore-plus": "^1.0.0"
   },
   "coffeelintConfig": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pathwatcher": "6.7.1",
     "regression": "^1.2.1",
     "serializable": "^1.0.3",
-    "superstring": "0.0.6",
+    "superstring": "0.0.7",
     "underscore-plus": "^1.0.0"
   },
   "coffeelintConfig": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pathwatcher": "6.7.1",
     "regression": "^1.2.1",
     "serializable": "^1.0.3",
-    "superstring": "0.0.4",
+    "superstring": "0.0.5",
     "underscore-plus": "^1.0.0"
   },
   "coffeelintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.4.1-0",
+  "version": "9.4.1-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -51,12 +51,11 @@
     "event-kit": "^2.1.0",
     "fs-plus": "^2.0.0",
     "grim": "1.5.0",
-    "line-length-index": "0.0.2",
     "marker-index": "4.0.1",
     "pathwatcher": "6.7.1",
     "regression": "^1.2.1",
     "serializable": "^1.0.3",
-    "span-skip-list": "~0.2.0",
+    "superstring": "0.0.3",
     "underscore-plus": "^1.0.0"
   },
   "coffeelintConfig": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pathwatcher": "6.7.1",
     "regression": "^1.2.1",
     "serializable": "^1.0.3",
-    "superstring": "0.0.7",
+    "superstring": "0.0.8",
     "underscore-plus": "^1.0.0"
   },
   "coffeelintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.4.0",
+  "version": "9.4.1-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "9.4.1-1",
+  "version": "9.4.1-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1,6 +1,6 @@
 {Emitter, CompositeDisposable, Disposable} = require 'event-kit'
 {File} = require 'pathwatcher'
-SpanSkipList = require 'span-skip-list'
+{BufferOffsetIndex} = require 'superstring'
 diff = require 'diff'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
@@ -97,7 +97,7 @@ class TextBuffer
     @id = params?.id ? crypto.randomBytes(16).toString('hex')
     @lines = ['']
     @lineEndings = ['']
-    @offsetIndex = new SpanSkipList('rows', 'characters')
+    @offsetIndex = new BufferOffsetIndex()
     @textDecorationLayers = new Set()
     @setTextInRange([[0, 0], [0, 0]], text ? params?.text ? '', normalizeLineEndings: false)
     maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
@@ -749,9 +749,7 @@ class TextBuffer
     spliceArray(@lineEndings, startRow, rowCount, lineEndings)
 
     # Update the offset index for position <-> character offset translation
-    offsets = lines.map (line, index) ->
-      {rows: 1, characters: line.length + lineEndings[index].length}
-    @offsetIndex.spliceArray('rows', startRow, rowCount, offsets)
+    @offsetIndex.splice(startRow, rowCount, lines.map((line, i) -> line.length + lineEndings[i].length))
 
     if @markerLayers?
       oldExtent = oldRange.getExtent()
@@ -1252,7 +1250,7 @@ class TextBuffer
   #
   # Returns a {Number}.
   getMaxCharacterIndex: ->
-    @offsetIndex.totalTo(Infinity, 'rows').characters
+    @characterIndexForPosition(Point.INFINITY)
 
   # Public: Get the range for the given row
   #
@@ -1280,13 +1278,8 @@ class TextBuffer
   #
   # Returns a {Number}.
   characterIndexForPosition: (position) ->
-    {row, column} = @clipPosition(Point.fromObject(position))
-
-    if row < 0 or row > @getLastRow() or column < 0 or column > @lineLengthForRow(row)
-      throw new Error("Position #{position} is invalid")
-
-    {characters} = @offsetIndex.totalTo(row, 'rows')
-    characters + column
+    position = @clipPosition(Point.fromObject(position))
+    @offsetIndex.characterIndexForPosition(position)
 
   # Public: Convert an absolute character offset, inclusive of newlines, to a
   # position in the buffer in row/column coordinates.
@@ -1297,14 +1290,8 @@ class TextBuffer
   #
   # Returns a {Point}.
   positionForCharacterIndex: (offset) ->
-    offset = Math.max(0, offset)
-    offset = Math.min(@getMaxCharacterIndex(), offset)
-
-    {rows, characters} = @offsetIndex.totalTo(offset, 'characters')
-    if rows > @getLastRow()
-      @getEndPosition()
-    else
-      new Point(rows, offset - characters)
+    position = @offsetIndex.positionForCharacterIndex(Math.max(0, offset))
+    new Point(position.row, position.column)
 
   # Public: Clip the given range so it starts and ends at valid positions.
   #


### PR DESCRIPTION
This is our first attempt at using Rust to optimize Atom's performance and memory usage. We are starting from a relatively simple data structure that powers `positionForCharacterIndex` and `characterIndexForPosition`, two methods that allow converting from/to buffer indices to/from two-dimensional coordinates.

Using a native implementation of this index yields a 2x improvement when opening editors in Atom:

![screen shot 2016-10-19 at 18 06 37](https://cloud.githubusercontent.com/assets/482957/19636543/41190432-99ca-11e6-9588-4340a943b0af.png)

Overall, memory usage should be improved too, as now each node in the the tree representation of the index occupies exactly 40 bytes.
