### PR TITLE
Optimize setTextInRange in the case of large new text.

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -746,8 +746,12 @@ class TextBuffer
     lineEndings[lastIndex] = lastLineEnding
 
     # Replace lines in oldRange with new lines
-    spliceArray(@lines, startRow, rowCount, lines)
-    spliceArray(@lineEndings, startRow, rowCount, lineEndings)
+    if @lines.length > 1 or @lines[0].length > 0
+      spliceArray(@lines, startRow, rowCount, lines)
+      spliceArray(@lineEndings, startRow, rowCount, lineEndings)
+    else
+      @lines = lines
+      @lineEndings = lineEndings
 
     # Update the offset index for position <-> character offset translation
     @offsetIndex.splice(startRow, rowCount, lines.map((line, i) -> line.length + lineEndings[i].length))


### PR DESCRIPTION
1. When initially loading large files or processing large insertions of text, `Range.fromText` takes significant time to count the lines in a string. We can avoid this call by waiting to define the new range until after splicing into the lines array, at which point we've already counted the lines.

2. In `applyChange`, we always splice the new lines and line endings into the buffer's `lines` and `lineEndings` arrays. When initially populating the buffer, we can save a lot of time by simply *replacing* those arrays.

These optimizations save over 200ms on my laptop when opening a 450,000-line file.

/cc @nathansobo 