### PR TITLE
Optimize scan when using single-line regexps

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -3,8 +3,7 @@ const dedent = require('dedent')
 const TextBuffer = require('../src/text-buffer')
 const Point = require('../src/point')
 const Range = require('../src/range')
-
-const WORDS = require('./helpers/words')
+const {buildRandomLines, getRandomBufferRange} = require('./helpers/random')
 const SAMPLE_TEXT = require('./helpers/sample-text')
 const TestDecorationLayer = require('./helpers/test-decoration-layer')
 
@@ -2163,7 +2162,7 @@ describe('DisplayLayer', () => {
 
 function performRandomChange (random, displayLayer) {
   const text = buildRandomLines(random, 4)
-  const range = getRandomBufferRange(random, displayLayer)
+  const range = getRandomBufferRange(random, displayLayer.buffer)
   log(('buffer change ' + (range) + ' ' + (JSON.stringify(text))))
 
   verifyChangeEvent(displayLayer, () => {
@@ -2188,7 +2187,7 @@ function performRedo (random, displayLayer) {
 }
 
 function createRandomFold (random, displayLayer, foldIds) {
-  const bufferRange = getRandomBufferRange(random, displayLayer)
+  const bufferRange = getRandomBufferRange(random, displayLayer.buffer)
   log('fold ' + bufferRange)
 
   verifyChangeEvent(displayLayer, () => {
@@ -2314,46 +2313,6 @@ function verifyPositionTranslations (random, displayLayer) {
     const nextScreenPosition = displayLayer.translateBufferPosition(nextBufferPosition)
     expect(nextScreenPosition.isGreaterThan(screenPosition)).toBe(true, `translateBufferPosition(${nextBufferPosition}) > translateBufferPosition(${bufferPosition})`)
   }
-}
-
-function buildRandomLines (random, maxLines) {
-  const lines = []
-
-  for (let i = 0; i < random(maxLines); i++) {
-    lines.push(buildRandomLine(random))
-  }
-
-  return lines.join('\n')
-}
-
-function buildRandomLine (random) {
-  const line = []
-
-  for (let i = 0; i < random(5); i++) {
-    const n = random(10)
-
-    if (n < 2) {
-      line.push('\t')
-    } else if (n < 4) {
-      line.push(' ')
-    } else {
-      if (line.length > 0 && !/\s/.test(line[line.length - 1])) {
-        line.push(' ')
-      }
-
-      line.push(WORDS[random(WORDS.length)])
-    }
-  }
-
-  return line.join('')
-}
-
-function getRandomBufferRange (random, displayLayer) {
-  const endRow = random(displayLayer.buffer.getLineCount())
-  const startRow = random.intBetween(0, endRow)
-  const startColumn = random(displayLayer.buffer.lineForRow(startRow).length + 1)
-  const endColumn = random(displayLayer.buffer.lineForRow(endRow).length + 1)
-  return Range(Point(startRow, startColumn), Point(endRow, endColumn))
 }
 
 function expectPositionTranslations (displayLayer, tranlations) {

--- a/spec/helpers/random.js
+++ b/spec/helpers/random.js
@@ -1,0 +1,43 @@
+const WORDS = require('./words')
+const Point = require('../../src/point')
+const Range = require('../../src/range')
+
+exports.getRandomBufferRange = function getRandomBufferRange (random, buffer) {
+  const endRow = random(buffer.getLineCount())
+  const startRow = random.intBetween(0, endRow)
+  const startColumn = random(buffer.lineForRow(startRow).length + 1)
+  const endColumn = random(buffer.lineForRow(endRow).length + 1)
+  return Range(Point(startRow, startColumn), Point(endRow, endColumn))
+}
+
+exports.buildRandomLines = function buildRandomLines (random, maxLines) {
+  const lines = []
+
+  for (let i = 0; i < random(maxLines); i++) {
+    lines.push(buildRandomLine(random))
+  }
+
+  return lines.join('\n')
+}
+
+function buildRandomLine (random) {
+  const line = []
+
+  for (let i = 0; i < random(5); i++) {
+    const n = random(10)
+
+    if (n < 2) {
+      line.push('\t')
+    } else if (n < 4) {
+      line.push(' ')
+    } else {
+      if (line.length > 0 && !/\s/.test(line[line.length - 1])) {
+        line.push(' ')
+      }
+
+      line.push(WORDS[random(WORDS.length)])
+    }
+  }
+
+  return line.join('')
+}

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2045,10 +2045,10 @@ describe "TextBuffer", ->
 
   describe "::scanInRange(range, regex, fn)", ->
     beforeEach (done) ->
+    beforeEach ->
       filePath = require.resolve('./fixtures/sample.js')
       buffer = new TextBuffer({filePath, load: false})
-      buffer.load().then ->
-        done()
+      buffer.loadSync()
 
     describe "when given a regex with a ignore case flag", ->
       it "does a case-insensitive search", ->
@@ -2161,11 +2161,10 @@ describe "TextBuffer", ->
         expect(ranges.length).toBe 2
 
   describe "::backwardsScanInRange(range, regex, fn)", ->
-    beforeEach (done) ->
+    beforeEach ->
       filePath = require.resolve('./fixtures/sample.js')
       buffer = new TextBuffer({filePath, load: false})
-      buffer.load().then ->
-        done()
+      buffer.loadSync()
 
     describe "when given a regex with no global flag", ->
       it "calls the iterator with the last match for the given regex in the given range", ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -2,6 +2,8 @@ Point = require './point'
 
 SpliceArrayChunkSize = 100000
 
+MULTI_LINE_REGEX_REGEX = /[\r\n\[]/
+
 module.exports =
   spliceArray: (originalArray, start, length, insertedArray=[]) ->
     if insertedArray.length < SpliceArrayChunkSize
@@ -23,3 +25,6 @@ module.exports =
       newExtent: Point.fromObject(change.newExtent)
       newText: change.newText
     }
+
+  regexIsSingleLine: (regex) ->
+    not MULTI_LINE_REGEX_REGEX.test(regex.source)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -2,7 +2,7 @@ Point = require './point'
 
 SpliceArrayChunkSize = 100000
 
-MULTI_LINE_REGEX_REGEX = /\r|\n|^\[\^|[^\\]\[\^/
+MULTI_LINE_REGEX_REGEX = /\\r|\\n|^\[\^|[^\\]\[\^/
 
 module.exports =
   spliceArray: (originalArray, start, length, insertedArray=[]) ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -2,7 +2,7 @@ Point = require './point'
 
 SpliceArrayChunkSize = 100000
 
-MULTI_LINE_REGEX_REGEX = /[\r\n\[]/
+MULTI_LINE_REGEX_REGEX = /\r|\n|^\[\^|[^\\]\[\^/
 
 module.exports =
   spliceArray: (originalArray, start, length, insertedArray=[]) ->

--- a/src/match-iterator.coffee
+++ b/src/match-iterator.coffee
@@ -2,7 +2,9 @@ Point = require './point'
 Range = require './range'
 
 class SingleLineSearchCallbackArgument
-  Object.defineProperty @::, "range",
+  lineTextOffset: 0
+
+  Object.defineProperty @::, 'range',
     get: ->
       @computedRange ?= Range(
         Point(@row, @lineOffset + @match.index),
@@ -10,6 +12,9 @@ class SingleLineSearchCallbackArgument
       )
 
     set: (@computedRange) ->
+
+  Object.defineProperty @::, 'lineText',
+    get: -> @buffer.lineForRow(@row)
 
   constructor: (@buffer, @row, @match, @lineOffset) ->
     @stopped = false
@@ -87,7 +92,9 @@ class BackwardsSingleLine
       return if argument.stopped or not global
 
 class MultiLineSearchCallbackArgument
-  Object.defineProperty @::, "range",
+  lineTextOffset: 0
+
+  Object.defineProperty @::, 'range',
     get: ->
       return @computedRange if @computedRange?
 
@@ -101,6 +108,9 @@ class MultiLineSearchCallbackArgument
 
     set: (range) ->
       @computedRange = range
+
+  Object.defineProperty @::, 'lineText',
+    get: -> @buffer.lineForRow(@range.start.row)
 
   constructor: (@buffer, @match, @lengthDelta) ->
     @stopped = false

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1124,7 +1124,7 @@ class TextBuffer
 
     if regexIsSingleLine(regex)
       if reverse
-        iterator = new MatchIterator.BackwardsSingleLine(this, regex, range, @backwardsScanChunkSize)
+        iterator = new MatchIterator.BackwardsSingleLine(this, regex, range)
       else
         iterator = new MatchIterator.ForwardsSingleLine(this, regex, range)
     else

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1087,10 +1087,7 @@ class TextBuffer
   #   * `stop` Call this {Function} to terminate the scan.
   #   * `replace` Call this {Function} with a {String} to replace the match.
   scan: (regex, iterator) ->
-    @scanInRange regex, @getRange(), (result) =>
-      result.lineText = @lineForRow(result.range.start.row)
-      result.lineTextOffset = 0
-      iterator(result)
+    @scanInRange(regex, @getRange(), iterator)
 
   # Public: Scan regular expression matches in the entire buffer in reverse
   # order, calling the given iterator function on each match.
@@ -1104,10 +1101,7 @@ class TextBuffer
   #   * `stop` Call this {Function} to terminate the scan.
   #   * `replace` Call this {Function} with a {String} to replace the match.
   backwardsScan: (regex, iterator) ->
-    @backwardsScanInRange regex, @getRange(), (result) =>
-      result.lineText = @lineForRow(result.range.start.row)
-      result.lineTextOffset = 0
-      iterator(result)
+    @backwardsScanInRange(regex, @getRange(), iterator)
 
   # Public: Scan regular expression matches in a given range , calling the given
   # iterator function on each match.


### PR DESCRIPTION
Most of the time when searching a buffer, the search regex can only match within a single line. This is the case whenever the regex doesn't contain an explicit line ending character (`\n` or `\r`) or a negated character class (e.g. `[^\w]`). In this situation, we can avoid two inefficient aspects of the current search algorithm:

1. We can avoid joining the buffer's text into a single string to pass to `Regex.exec` and then translating the resulting match positions back into 2-dimensional buffer ranges with the `BufferOffsetIndex`. Instead we can search each line individually, keeping track of the row as we go, so that we can provide the ranges with no cost.

2. When searching backwards, there's no need for the back-off algorithm that we currently use to avoid searching from the beginning of the text. We can simply iterate through the lines in reverse.

/cc @nathansobo 