### PR TITLE
Handle empty final row in TextBuffer.scanInRange

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2212,6 +2212,16 @@ describe "TextBuffer", ->
         ranges.push(range)
       expect(ranges).toEqual([[[1, 0], [1, 2]]])
 
+    it "returns a single empty match on the final line of the range", ->
+      ranges = []
+
+      buffer.scanInRange /^\s*/gm, [[9, 0], [10, 0]], ({range}) -> ranges.push(range)
+      expect(ranges).toEqual([[[9, 0], [9, 2]], [[10, 0], [10, 0]]])
+
+      ranges.length = 0
+      buffer.scanInRange /^\s*/gm, [[10, 0], [10, 0]], ({range}) -> ranges.push(range)
+      expect(ranges).toEqual([[[10, 0], [10, 0]]])
+
   describe "::backwardsScanInRange(range, regex, fn)", ->
     beforeEach ->
       filePath = require.resolve('./fixtures/sample.js')

--- a/src/match-iterator.coffee
+++ b/src/match-iterator.coffee
@@ -52,7 +52,7 @@ class ForwardsSingleLine
 
     line = line.slice(0, @range.end.column - lineOffset)
     while match = @regex.exec(line)
-      break if match.index is @range.end.column
+      break if line.length isnt 0 and match.index is @range.end.column
       argument = new SingleLineSearchCallbackArgument(@buffer, row, match, lineOffset)
       callback(argument)
       return if argument.stopped or not global


### PR DESCRIPTION
If the final row of a range passed to `scanInRange` is empty, then the `break` statement shouldn't trigger on a match at the range's end, because a zero-length match _is_ a valid and expected result.

Manifesting in Atom as atom/atom#13489.