### PR TITLE
Allow fast creation and destruction of large numbers of display markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "10.1.0",
+  "version": "10.2.0-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/display-marker-layer-spec.coffee
+++ b/spec/display-marker-layer-spec.coffee
@@ -219,6 +219,51 @@ describe "DisplayMarkerLayer", ->
       # ::onDidDestroy listener
       expect(marker2.isDestroyed()).toBe(true)
 
+  describe "::clear()", ->
+    it "destroys all of the layer's markers", ->
+      buffer = new TextBuffer(text: 'abc')
+      displayLayer = buffer.addDisplayLayer()
+      displayMarkerLayer = displayLayer.addMarkerLayer()
+
+      displayMarker1 = displayMarkerLayer.markBufferRange([[0, 1], [0, 2]])
+      displayMarker2 = displayMarkerLayer.markBufferRange([[0, 1], [0, 2]])
+      displayMarker1DestroyCount = 0
+      displayMarker2DestroyCount = 0
+      layerUpdateCount = 0
+      displayMarker1.onDidDestroy -> displayMarker1DestroyCount++
+      displayMarker2.onDidDestroy -> displayMarker2DestroyCount++
+      displayMarkerLayer.onDidUpdate -> layerUpdateCount++
+
+      displayMarkerLayer.clear()
+      expect(displayMarker1DestroyCount).toBe(1)
+      expect(displayMarker2DestroyCount).toBe(1)
+      expect(layerUpdateCount).toBe(1)
+      expect(displayMarkerLayer.getMarkers()).toEqual([])
+
+  it "destroys display markers when their underlying buffer markers are destroyed", ->
+    buffer = new TextBuffer(text: '\tabc')
+    displayLayer1 = buffer.addDisplayLayer(tabLength: 2)
+    displayLayer2 = buffer.addDisplayLayer(tabLength: 4)
+    bufferMarkerLayer = buffer.addMarkerLayer()
+    displayMarkerLayer1 = displayLayer1.getMarkerLayer(bufferMarkerLayer.id)
+    displayMarkerLayer2 = displayLayer2.getMarkerLayer(bufferMarkerLayer.id)
+
+    bufferMarker = bufferMarkerLayer.markRange([[0, 1], [0, 2]])
+
+    displayMarker1 = displayMarkerLayer1.getMarker(bufferMarker.id)
+    displayMarker2 = displayMarkerLayer2.getMarker(bufferMarker.id)
+    expect(displayMarker1.getScreenRange()).toEqual([[0, 2], [0, 3]])
+    expect(displayMarker2.getScreenRange()).toEqual([[0, 4], [0, 5]])
+
+    displayMarker1DestroyCount = 0
+    displayMarker2DestroyCount = 0
+    displayMarker1.onDidDestroy -> displayMarker1DestroyCount++
+    displayMarker2.onDidDestroy -> displayMarker2DestroyCount++
+
+    bufferMarker.destroy()
+    expect(displayMarker1DestroyCount).toBe(1)
+    expect(displayMarker2DestroyCount).toBe(1)
+
   it "destroys itself when the underlying buffer marker layer is destroyed", ->
     buffer = new TextBuffer(text: 'abc\ndef\nghi\nj\tk\tl\nmno')
     displayLayer1 = buffer.addDisplayLayer(tabLength: 2)

--- a/src/display-marker.coffee
+++ b/src/display-marker.coffee
@@ -49,9 +49,8 @@ class DisplayMarker
     {@id} = @bufferMarker
     @hasChangeObservers = false
     @emitter = new Emitter
-    @disposables = new CompositeDisposable
     @destroyed = false
-    @disposables.add @bufferMarker.onDidDestroy(@destroy.bind(this))
+    @bufferMarkerSubscription = null
 
   # Essential: Destroys the marker, causing it to emit the 'destroyed' event. Once
   # destroyed, a marker cannot be restored by undo/redo operations.
@@ -59,12 +58,11 @@ class DisplayMarker
     return if @destroyed
 
     @destroyed = true
-    @layer.markersWithDestroyListeners.delete(this)
     @bufferMarker.destroy()
     @emitter.emit('did-destroy')
     @layer.didDestroyMarker(this)
     @emitter.dispose()
-    @disposables.dispose()
+    @bufferMarkerSubscription?.dispose()
 
   # Essential: Creates and returns a new {DisplayMarker} with the same properties as
   # this marker.
@@ -116,7 +114,7 @@ class DisplayMarker
       @oldTailBufferPosition = @getTailBufferPosition()
       @oldTailScreenPosition = @getTailScreenPosition()
       @wasValid = @isValid()
-      @disposables.add @bufferMarker.onDidChange (event) => @notifyObservers(event.textChanged)
+      @bufferMarkerSubscription = @bufferMarker.onDidChange (event) => @notifyObservers(event.textChanged)
       @hasChangeObservers = true
     @emitter.on 'did-change', callback
 

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -296,10 +296,8 @@ class Marker
   # Public: Destroys the marker, causing it to emit the 'destroyed' event.
   destroy: ->
     return if @rangeWhenDestroyed?
-    @layer.markersWithChangeListeners.delete(this)
-    @layer.markersWithDestroyListeners.delete(this)
     @rangeWhenDestroyed = @getRange()
-    @layer.destroyMarker(@id)
+    @layer.destroyMarker(this)
     @emitter.emit 'did-destroy'
 
   # Public: Compares this marker to another based on their ranges.


### PR DESCRIPTION
* Add `clear` method to `MarkerLayer` and `DisplayMarkerLayer`
* Avoid using `Marker.onDidDestroy` in `DisplayMarker` constructor