### PR TITLE
Reduce the memory impact of leaking destroyed objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "10.2.1",
+  "version": "10.2.2-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "10.2.2-0",
+  "version": "10.2.2-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "10.2.2-1",
+  "version": "10.2.2-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -62,6 +62,20 @@ describe('DisplayLayer', () => {
     })
   })
 
+  describe('destroy', function () {
+    it('does not throw exceptions when queried after destruction', function () {
+      const buffer = new TextBuffer({text: 'hi'})
+
+      const displayLayer = buffer.addDisplayLayer({})
+
+      displayLayer.destroy()
+
+      expect(displayLayer.isDestroyed()).toBe(true)
+      expect(displayLayer.getText()).toBe('hi')
+      expect(displayLayer.translateScreenPosition(Point(0, 0))).toEqual(Point(0, 0))
+    })
+  })
+
   describe('hard tabs', () => {
     it('expands hard tabs to their tab stops', () => {
       const buffer = new TextBuffer({

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -43,7 +43,9 @@ describe "MarkerLayer", ->
     buffer.undo()
     expect(defaultMarker.getRange()).toEqual [[0, 3], [0, 6]]
     expect(layer1Marker.getRange()).toEqual [[0, 4], [0, 7]]
-    expect(layer2Marker.getRange()).toEqual [[0, 7], [0, 10]]
+
+    expect(layer2Marker.isDestroyed()).toBe true
+    expect(layer2Marker.getRange()).toEqual [[0, 0], [0, 0]]
 
   it "emits onDidCreateMarker events synchronously when markers are created", ->
     createdMarkers = []

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -654,6 +654,7 @@ describe "Marker", ->
       expect(buffer.getMarker(marker.id)).toBeUndefined()
       expect(marker.isDestroyed()).toBe true
       expect(marker.isValid()).toBe false
+      expect(marker.getRange()).toEqual [[0, 0], [0, 0]]
 
     it "handles markers deleted in event handlers", ->
       marker1 = buffer.markRange([[0, 3], [0, 6]])
@@ -679,15 +680,6 @@ describe "Marker", ->
 
       # doesn't blow up.
       buffer.undo()
-
-    it "allows the position to be retrieved after destruction", ->
-      marker = buffer.markRange([[0, 3], [0, 6]])
-      marker.destroy()
-      expect(marker.getRange()).toEqual [[0, 3], [0, 6]]
-      expect(marker.getHeadPosition()).toEqual [0, 6]
-      expect(marker.getTailPosition()).toEqual [0, 3]
-      expect(marker.getStartPosition()).toEqual [0, 3]
-      expect(marker.getEndPosition()).toEqual [0, 6]
 
     it "does not reinsert the marker if its range is later updated", ->
       marker = buffer.markRange([[0, 3], [0, 6]])

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -91,6 +91,20 @@ describe "TextBuffer", ->
             expect(buffer.getText()).toBe ''
             done()
 
+  describe "::destroy()", ->
+    it "clears the buffer's state", ->
+      filePath = temp.openSync('atom').path
+      buffer = new TextBuffer()
+      buffer.setPath(filePath)
+      buffer.append("a")
+      buffer.append("b")
+      buffer.destroy()
+
+      expect(buffer.getText()).toBe('')
+      buffer.undo()
+      expect(buffer.getText()).toBe('')
+      expect(-> buffer.save()).toThrowError(/Can't save destroyed buffer/)
+
   describe "::setTextInRange(range, text)", ->
     beforeEach ->
       buffer = new TextBuffer("hello\nworld\r\nhow are you doing?")

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -111,6 +111,8 @@ class DisplayLayer {
   }
 
   destroy () {
+    if (this.destroyed) return
+    this.destroyed = true
     this.textDecorationLayer = null
     this.emitter = null
     this.spatialIndex = null

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -22,6 +22,7 @@ class DisplayLayer {
     this.nextOpenTagCode = -1
     this.textDecorationLayer = new EmptyDecorationLayer()
     this.displayMarkerLayersById = new Map()
+    this.destroyed = false
 
     this.invisibles = params.invisibles != null ? params.invisibles : {}
     this.tabLength = params.tabLength != null ? params.tabLength : 4
@@ -76,11 +77,7 @@ class DisplayLayer {
 
   reset (params) {
     if (!this.isDestroyed() && this.setParams(params)) {
-      this.indexedBufferRowCount = 0
-      this.spatialIndex.spliceOld(Point.ZERO, Point.INFINITY, Point.INFINITY)
-      this.cachedScreenLines.length = 0
-      this.screenLineLengths.length = 0
-      this.tabCounts.length = 0
+      this.clearSpatialIndex()
       this.emitter.emit('did-reset')
       this.notifyObserversIfMarkerScreenPositionsChanged()
     }
@@ -113,25 +110,23 @@ class DisplayLayer {
   destroy () {
     if (this.destroyed) return
     this.destroyed = true
-    this.textDecorationLayer = null
-    this.emitter = null
-    this.spatialIndex = null
-    this.tabCounts = null
-    this.screenLineLengths = null
-    this.cachedScreenLines = null
-    this.tagsByCode = null
-    this.codesByTag = null
+    this.clearSpatialIndex()
     this.foldsMarkerLayer.destroy()
-    this.foldsMarkerLayer = null
     this.displayMarkerLayersById.forEach((layer) => layer.destroy())
-    this.displayMarkerLayersById = null
     if (this.decorationLayerDisposable) this.decorationLayerDisposable.dispose()
     delete this.buffer.displayLayers[this.id]
-    this.buffer = null
   }
 
   isDestroyed () {
-    return this.spatialIndex === null
+    return this.destroyed
+  }
+
+  clearSpatialIndex () {
+    this.indexedBufferRowCount = 0
+    this.spatialIndex.spliceOld(Point.ZERO, Point.INFINITY, Point.INFINITY)
+    this.cachedScreenLines.length = 0
+    this.screenLineLengths.length = 0
+    this.tabCounts.length = 0
   }
 
   doBackgroundWork (deadline) {

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -111,12 +111,21 @@ class DisplayLayer {
   }
 
   destroy () {
+    this.textDecorationLayer = null
+    this.emitter = null
     this.spatialIndex = null
+    this.tabCounts = null
     this.screenLineLengths = null
+    this.cachedScreenLines = null
+    this.tagsByCode = null
+    this.codesByTag = null
     this.foldsMarkerLayer.destroy()
+    this.foldsMarkerLayer = null
     this.displayMarkerLayersById.forEach((layer) => layer.destroy())
+    this.displayMarkerLayersById = null
     if (this.decorationLayerDisposable) this.decorationLayerDisposable.dispose()
     delete this.buffer.displayLayers[this.id]
+    this.buffer = null
   }
 
   isDestroyed () {

--- a/src/display-marker-layer.coffee
+++ b/src/display-marker-layer.coffee
@@ -25,13 +25,14 @@ class DisplayMarkerLayer
 
   # Essential: Destroy this layer.
   destroy: ->
-    @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
-    @destroyed = true
-    @subscriptions.dispose()
-    @bufferMarkerLayer.displayMarkerLayers.delete(this)
-    @bufferMarkerLayer.destroy() if @ownsBufferMarkerLayer
-    @displayLayer.didDestroyMarkerLayer(@id)
-    @emitter.emit('did-destroy')
+    unless @destroyed
+      @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
+      @destroyed = true
+      @subscriptions.dispose()
+      @bufferMarkerLayer.displayMarkerLayers.delete(this)
+      @bufferMarkerLayer.destroy() if @ownsBufferMarkerLayer
+      @displayLayer.didDestroyMarkerLayer(@id)
+      @emitter.emit('did-destroy')
 
   # Public: Destroy all markers in this layer.
   clear: ->

--- a/src/display-marker-layer.coffee
+++ b/src/display-marker-layer.coffee
@@ -25,14 +25,15 @@ class DisplayMarkerLayer
 
   # Essential: Destroy this layer.
   destroy: ->
-    unless @destroyed
-      @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
-      @destroyed = true
-      @subscriptions.dispose()
-      @bufferMarkerLayer.displayMarkerLayers.delete(this)
-      @bufferMarkerLayer.destroy() if @ownsBufferMarkerLayer
-      @displayLayer.didDestroyMarkerLayer(@id)
-      @emitter.emit('did-destroy')
+    return if @destroyed
+    @destroyed = true
+    @clear()
+    @subscriptions.dispose()
+    @bufferMarkerLayer.displayMarkerLayers.delete(this)
+    @bufferMarkerLayer.destroy() if @ownsBufferMarkerLayer
+    @displayLayer.didDestroyMarkerLayer(@id)
+    @emitter.emit('did-destroy')
+    @emitter.clear()
 
   # Public: Destroy all markers in this layer.
   clear: ->

--- a/src/display-marker.coffee
+++ b/src/display-marker.coffee
@@ -62,6 +62,8 @@ class DisplayMarker
     @emitter.emit('did-destroy')
     @layer.didDestroyMarker(this)
     @emitter.dispose()
+    @emitter = null
+    @layer = null
     @bufferMarkerSubscription?.dispose()
 
   # Essential: Creates and returns a new {DisplayMarker} with the same properties as

--- a/src/display-marker.coffee
+++ b/src/display-marker.coffee
@@ -144,7 +144,7 @@ class DisplayMarker
   # undoing the invalidating operation would restore the marker. Once a marker
   # is destroyed by calling {DisplayMarker::destroy}, no undo/redo operation
   # can ever bring it back.
-  isDestroyed: -> @layer.isDestroyed() or @destroyed
+  isDestroyed: -> @destroyed or @layer.isDestroyed()
 
   # Essential: Returns a {Boolean} indicating whether the head precedes the tail.
   isReversed: ->

--- a/src/display-marker.coffee
+++ b/src/display-marker.coffee
@@ -62,8 +62,7 @@ class DisplayMarker
     @emitter.emit('did-destroy')
     @layer.didDestroyMarker(this)
     @emitter.dispose()
-    @emitter = null
-    @layer = null
+    @emitter.clear()
     @bufferMarkerSubscription?.dispose()
 
   # Essential: Creates and returns a new {DisplayMarker} with the same properties as

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -217,6 +217,10 @@ class History
     else
       false
 
+  clear: ->
+    @clearUndoStack()
+    @clearRedoStack()
+
   clearUndoStack: ->
     @undoStack.length = 0
 

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -55,17 +55,14 @@ class MarkerLayer
 
   # Public: Destroy this layer.
   destroy: ->
-    unless @destroyed
-      @destroyed = true
-      @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
-      @delegate.markerLayerDestroyed(this)
-      @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroy()
-      @emitter.emit 'did-destroy'
-      @emitter = null
-      @index = null
-      @markersById = null
-      @displayMarkerLayers = null
-      @markersWithDestroyListeners = null
+    return if @destroyed
+    @destroyed = true
+    @clear()
+    @delegate.markerLayerDestroyed(this)
+    @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroy()
+    @displayMarkerLayers.clear()
+    @emitter.emit 'did-destroy'
+    @emitter.clear()
 
   # Public: Remove all markers from this layer.
   clear: ->

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -55,12 +55,16 @@ class MarkerLayer
 
   # Public: Destroy this layer.
   destroy: ->
-    @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
     @destroyed = true
+    @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
     @delegate.markerLayerDestroyed(this)
     @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroy()
     @emitter.emit 'did-destroy'
-    @emitter.dispose()
+    @emitter = null
+    @index = null
+    @markersById = null
+    @displayMarkerLayers = null
+    @markersWithDestroyListeners = null
 
   # Public: Remove all markers from this layer.
   clear: ->
@@ -385,6 +389,7 @@ class MarkerLayer
     unless @didUpdateEventScheduled
       @didUpdateEventScheduled = true
       process.nextTick =>
+        return if @destroyed
         @didUpdateEventScheduled = false
         @emitter.emit 'did-update'
 

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -55,16 +55,17 @@ class MarkerLayer
 
   # Public: Destroy this layer.
   destroy: ->
-    @destroyed = true
-    @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
-    @delegate.markerLayerDestroyed(this)
-    @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroy()
-    @emitter.emit 'did-destroy'
-    @emitter = null
-    @index = null
-    @markersById = null
-    @displayMarkerLayers = null
-    @markersWithDestroyListeners = null
+    unless @destroyed
+      @destroyed = true
+      @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
+      @delegate.markerLayerDestroyed(this)
+      @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroy()
+      @emitter.emit 'did-destroy'
+      @emitter = null
+      @index = null
+      @markersById = null
+      @displayMarkerLayers = null
+      @markersWithDestroyListeners = null
 
   # Public: Remove all markers from this layer.
   clear: ->

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -237,7 +237,7 @@ class Marker
   #
   # Returns a {Boolean}.
   isDestroyed: ->
-    @layer.isDestroyed() or @rangeWhenDestroyed?
+    @rangeWhenDestroyed? or not @layer?
 
   # Public: Returns a {Boolean} indicating whether changes that occur exactly at
   # the marker's head or tail cause it to move.

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -298,6 +298,7 @@ class Marker
     return if @rangeWhenDestroyed?
     @rangeWhenDestroyed = @getRange()
     @layer.destroyMarker(this)
+    @layer = null
     @emitter.emit 'did-destroy'
 
   # Public: Compares this marker to another based on their ranges.

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1417,10 +1417,22 @@ class TextBuffer
 
   destroy: ->
     unless @destroyed
-      @cancelStoppedChangingTimeout()
-      @fileSubscriptions?.dispose()
       @destroyed = true
       @emitter.emit 'did-destroy'
+      @emitter = null
+
+      @cancelStoppedChangingTimeout()
+      @fileSubscriptions?.dispose()
+      @displayLayers = null
+      @textDecorationLayers = null
+      for id, markerLayer of @markerLayers
+        markerLayer.destroy()
+      @markerLayers = null
+      @defaultMarkerLayer = null
+      @lines = null
+      @history = null
+      @cachedText = null
+      @cachedDiskContents = null
 
   isAlive: -> not @destroyed
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1334,6 +1334,7 @@ class TextBuffer
   #
   # Sets the buffer's content to the cached disk contents
   reload: (clearHistory=false) ->
+    return if @destroyed
     @emitter.emit 'will-reload'
     if clearHistory
       @clearUndoStack()


### PR DESCRIPTION
Tear down `TextBuffer`, `DisplayLayer`, `Marker` and friends more aggressively so that if these objects are leaked (e.g. due to bugs in Atom packages), they will use less memory.

🍐'd with @nathansobo