### PR TITLE
Fixes for preserved buffers of files deleted outside Atom

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1330,9 +1330,8 @@ describe "TextBuffer", ->
           done()
         fs.removeSync(filePath)
 
-      it "unsets its path and reports the buffer as modified", ->
-        expect(bufferToDelete.getPath()).toBe undefined
-        expect(bufferToDelete.file).toBe null
+      it "retains its path and reports the buffer as modified", ->
+        expect(bufferToDelete.getPath()).toBe filePath
         expect(bufferToDelete.isModified()).toBeTruthy()
 
     describe "when the file is deleted", ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1473,9 +1473,10 @@ class TextBuffer
         @reload()
 
     @fileSubscriptions.add @file.onDidDelete =>
+      modified = @getText() != @cachedDiskContents
       @emitter.emit 'did-delete'
       @updateCachedDiskContents()
-      if @shouldDestroyOnFileDelete()
+      if not modified and @shouldDestroyOnFileDelete()
         @destroy()
       else
         @emitModifiedStatusChanged(true)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1456,6 +1456,10 @@ class TextBuffer
     @fileSubscriptions = new CompositeDisposable
 
     @fileSubscriptions.add @file.onDidChange =>
+      # On Linux we get change events when the file is deleted. This yields
+      # consistent behavior with Mac/Windows.
+      return unless @file.existsSync()
+
       @conflict = true if @isModified()
       previousContents = @cachedDiskContents
 


### PR DESCRIPTION
This PR fixes three issues reported in atom/tabs#306:

- Linux behavior: now honors the setting, doesn't blank the editor.
- Now retains the path (and therefore tab name) for deleted files.
- Properly emits did-change-modified events so the UI correctly reflects the modified flag state.

Note the second item is accomplished by removing most of the difference in handling deletion of modified vs. unmodified files. They are now treated identically except that modified files ignore the setting: their buffers are always preserved.