### PR TITLE
Null guard destruction of markers in DisplayMarkerLayers

### DIFF
--- a/spec/display-marker-layer-spec.coffee
+++ b/spec/display-marker-layer-spec.coffee
@@ -264,6 +264,17 @@ describe "DisplayMarkerLayer", ->
     expect(displayMarker1DestroyCount).toBe(1)
     expect(displayMarker2DestroyCount).toBe(1)
 
+  it "does not throw exceptions when buffer markers are destroyed that don't have corresponding display markers", ->
+    buffer = new TextBuffer(text: '\tabc')
+    displayLayer1 = buffer.addDisplayLayer(tabLength: 2)
+    displayLayer2 = buffer.addDisplayLayer(tabLength: 4)
+    bufferMarkerLayer = buffer.addMarkerLayer()
+    displayMarkerLayer1 = displayLayer1.getMarkerLayer(bufferMarkerLayer.id)
+    displayMarkerLayer2 = displayLayer2.getMarkerLayer(bufferMarkerLayer.id)
+
+    bufferMarker = bufferMarkerLayer.markRange([[0, 1], [0, 2]])
+    bufferMarker.destroy()
+
   it "destroys itself when the underlying buffer marker layer is destroyed", ->
     buffer = new TextBuffer(text: 'abc\ndef\nghi\nj\tk\tl\nmno')
     displayLayer1 = buffer.addDisplayLayer(tabLength: 2)

--- a/src/display-marker-layer.coffee
+++ b/src/display-marker-layer.coffee
@@ -324,7 +324,8 @@ class DisplayMarkerLayer
     return
 
   destroyMarker: (id) ->
-    @markersById[id].destroy()
+    if marker = @markersById[id]
+      marker.destroy()
 
   didDestroyMarker: (marker) ->
     @markersWithDestroyListeners.delete(marker)


### PR DESCRIPTION
Refs atom/find-and-replace#855
Refs atom/atom#6899

`DisplayMarker`s are created lazily in their corresponding `DisplayMarkerLayer`s, so there's no guarantee that a display marker always exists for every `Marker` in the underlying `MarkerLayer`.