### PR TITLE
Ensure markers are destroyed when layer is cleared

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yargs": "^6.5.0"
   },
   "dependencies": {
-    "superstring": "1.0.9",
+    "superstring": "1.1.0",
     "delegato": "^1.0.0",
     "diff": "^2.2.1",
     "emissary": "^1.0.0",

--- a/spec/display-marker-layer-spec.coffee
+++ b/spec/display-marker-layer-spec.coffee
@@ -219,27 +219,6 @@ describe "DisplayMarkerLayer", ->
       # ::onDidDestroy listener
       expect(marker2.isDestroyed()).toBe(true)
 
-  describe "::clear()", ->
-    it "destroys all of the layer's markers", ->
-      buffer = new TextBuffer(text: 'abc')
-      displayLayer = buffer.addDisplayLayer()
-      displayMarkerLayer = displayLayer.addMarkerLayer()
-
-      displayMarker1 = displayMarkerLayer.markBufferRange([[0, 1], [0, 2]])
-      displayMarker2 = displayMarkerLayer.markBufferRange([[0, 1], [0, 2]])
-      displayMarker1DestroyCount = 0
-      displayMarker2DestroyCount = 0
-      layerUpdateCount = 0
-      displayMarker1.onDidDestroy -> displayMarker1DestroyCount++
-      displayMarker2.onDidDestroy -> displayMarker2DestroyCount++
-      displayMarkerLayer.onDidUpdate -> layerUpdateCount++
-
-      displayMarkerLayer.clear()
-      expect(displayMarker1DestroyCount).toBe(1)
-      expect(displayMarker2DestroyCount).toBe(1)
-      expect(layerUpdateCount).toBe(1)
-      expect(displayMarkerLayer.getMarkers()).toEqual([])
-
   it "destroys display markers when their underlying buffer markers are destroyed", ->
     buffer = new TextBuffer(text: '\tabc')
     displayLayer1 = buffer.addDisplayLayer(tabLength: 2)

--- a/src/display-marker-layer.coffee
+++ b/src/display-marker-layer.coffee
@@ -37,10 +37,11 @@ class DisplayMarkerLayer
 
   # Public: Destroy all markers in this layer.
   clear: ->
-    @markersWithDestroyListeners.forEach (marker) -> marker.destroy()
-    @markersById = {}
     @bufferMarkerLayer.clear()
-    @emitDidUpdate()
+
+  didClearBufferMarkerLayer: ->
+    @markersWithDestroyListeners.forEach (marker) -> marker.didDestroyBufferMarker()
+    @markersById = {}
 
   # Essential: Determine whether this layer has been destroyed.
   #
@@ -325,7 +326,7 @@ class DisplayMarkerLayer
 
   destroyMarker: (id) ->
     if marker = @markersById[id]
-      marker.destroy()
+      marker.didDestroyBufferMarker()
 
   didDestroyMarker: (marker) ->
     @markersWithDestroyListeners.delete(marker)

--- a/src/display-marker.coffee
+++ b/src/display-marker.coffee
@@ -49,16 +49,15 @@ class DisplayMarker
     {@id} = @bufferMarker
     @hasChangeObservers = false
     @emitter = new Emitter
-    @destroyed = false
     @bufferMarkerSubscription = null
 
   # Essential: Destroys the marker, causing it to emit the 'destroyed' event. Once
   # destroyed, a marker cannot be restored by undo/redo operations.
   destroy: ->
-    return if @destroyed
+    unless @isDestroyed()
+      @bufferMarker.destroy()
 
-    @destroyed = true
-    @bufferMarker.destroy()
+  didDestroyBufferMarker: ->
     @emitter.emit('did-destroy')
     @layer.didDestroyMarker(this)
     @emitter.dispose()
@@ -143,7 +142,8 @@ class DisplayMarker
   # undoing the invalidating operation would restore the marker. Once a marker
   # is destroyed by calling {DisplayMarker::destroy}, no undo/redo operation
   # can ever bring it back.
-  isDestroyed: -> @destroyed or @layer.isDestroyed()
+  isDestroyed: ->
+    @layer.isDestroyed() or @bufferMarker.isDestroyed()
 
   # Essential: Returns a {Boolean} indicating whether the head precedes the tail.
   isReversed: ->

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -56,11 +56,11 @@ class MarkerLayer
   # Public: Destroy this layer.
   destroy: ->
     return if @destroyed
-    @destroyed = true
     @clear()
     @delegate.markerLayerDestroyed(this)
     @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroy()
     @displayMarkerLayers.clear()
+    @destroyed = true
     @emitter.emit 'did-destroy'
     @emitter.clear()
 
@@ -70,6 +70,8 @@ class MarkerLayer
     @markersWithDestroyListeners.clear()
     @markersById = {}
     @index = new MarkerIndex
+    @displayMarkerLayers.forEach (layer) -> layer.didClearBufferMarkerLayer()
+    @scheduleUpdateEvent()
 
   # Public: Determine whether this layer has been destroyed.
   isDestroyed: ->
@@ -341,6 +343,9 @@ class MarkerLayer
       @index.delete(marker.id)
       @delegate.markersUpdated(this)
       @scheduleUpdateEvent()
+
+  hasMarker: (id) ->
+    not @destroyed and @index.has(id)
 
   getMarkerRange: (id) ->
     Range.fromObject(@index.getRange(id))

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -67,7 +67,6 @@ class Marker
     @invalidate ?= 'overlap'
     @properties ?= {}
     @hasChangeObservers = false
-    @destroyed = false
     Object.freeze(@properties)
     @layer.setMarkerIsExclusive(@id, @isExclusive())
 
@@ -234,7 +233,7 @@ class Marker
   #
   # Returns a {Boolean}.
   isDestroyed: ->
-    @destroyed or @layer.isDestroyed()
+    not @layer.hasMarker(@id)
 
   # Public: Returns a {Boolean} indicating whether changes that occur exactly at
   # the marker's head or tail cause it to move.
@@ -292,8 +291,7 @@ class Marker
 
   # Public: Destroys the marker, causing it to emit the 'destroyed' event.
   destroy: ->
-    return if @destroyed
-    @destroyed = true
+    return if @isDestroyed()
     @layer.destroyMarker(this)
     @emitter.emit 'did-destroy'
     @emitter.clear()


### PR DESCRIPTION
Previously, after a marker layer was cleared via the `.clear()` method, the `.isDestroyed()` method would incorrectly return `false` when called on any markers in that layer that didn't have any `onDidDestroy` observers.