### PR TITLE
Avoid the possibility of stack overflow in spliceArray helper

### DIFF
--- a/benchmarks/helpers.js
+++ b/benchmarks/helpers.js
@@ -1,9 +1,10 @@
 const WORDS = require('../spec/helpers/words')
 const Random = require('random-seed')
 const random = new Random(Date.now())
+const {Point, Range} = require('..')
 
 exports.getRandomText = function (sizeInKB) {
-  const goalLength = sizeInKB * 1024
+  const goalLength = Math.round(sizeInKB * 1024)
 
   let length = 0
   let lines = []
@@ -40,4 +41,20 @@ exports.getRandomText = function (sizeInKB) {
   }
 
   return lines.join('\n') + '\n'
+}
+
+exports.getRandomRange = function (buffer) {
+  const start = getRandomPoint(buffer)
+  const end = getRandomPoint(buffer)
+  if (end.isLessThan(start)) {
+    return new Range(end, start)
+  } else {
+    return new Range(start, end)
+  }
+}
+
+function getRandomPoint (buffer) {
+  const row = random(buffer.getLineCount())
+  const column = random(buffer.lineLengthForRow(row))
+  return new Point(row, column)
 }

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
 
 require('./construction')
+require('./mutation')

--- a/benchmarks/mutation.js
+++ b/benchmarks/mutation.js
@@ -1,0 +1,21 @@
+const helpers = require('./helpers')
+const TextBuffer = require('..')
+
+let text = helpers.getRandomText(100)
+let buffer = new TextBuffer({text})
+let displayLayer = buffer.addDisplayLayer({})
+
+let t0 = Date.now()
+
+for (let i = 0; i < 1000; i++) {
+  buffer.setTextInRange(
+    helpers.getRandomRange(buffer),
+    helpers.getRandomText(0.5)
+  )
+}
+
+let t1 = Date.now()
+
+console.log('Mutation')
+console.log('------------')
+console.log('TextBuffer:    %s ms', t1 - t0)

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -1,20 +1,27 @@
 Point = require './point'
 
-SpliceArrayChunkSize = 100000
-
 MULTI_LINE_REGEX_REGEX = /\\r|\\n|\r|\n|^\[\^|[^\\]\[\^/
 
 module.exports =
-  spliceArray: (originalArray, start, length, insertedArray=[]) ->
-    if insertedArray.length < SpliceArrayChunkSize
-      originalArray.splice(start, length, insertedArray...)
+  spliceArray: (array, start, removedCount, insertedItems=[]) ->
+    oldLength = array.length
+    insertedCount = insertedItems.length
+    removedCount = Math.min(removedCount, oldLength - start)
+    lengthDelta = insertedCount - removedCount
+    newLength = oldLength + lengthDelta
+
+    if lengthDelta > 0
+      array.length = newLength
+      for i in [(newLength - 1)..(start + insertedCount)] by -1
+        array[i] = array[i - lengthDelta]
     else
-      removedValues = originalArray.splice(start, length)
-      for chunkStart in [0..insertedArray.length] by SpliceArrayChunkSize
-        chunkEnd = chunkStart + SpliceArrayChunkSize
-        chunk = insertedArray.slice(chunkStart, chunkEnd)
-        originalArray.splice(start + chunkStart, 0, chunk...)
-      removedValues
+      for i in [(start + insertedCount)...newLength] by 1
+        array[i] = array[i - lengthDelta]
+      array.length = newLength
+
+    for value, i in insertedItems by 1
+      array[start + i] = insertedItems[i]
+    return
 
   newlineRegex: /\r\n|\n|\r/g
 


### PR DESCRIPTION
We're seeing some errors like this in bugsnag:

```
RangeError Maximum call stack size exceeded 
    /app.asar/node_modules/text-buffer/lib/helpers.js:18:37 spliceArray
    /app.asar/node_modules/text-buffer/lib/display-layer.js:924:5 updateSpatialIndex
    /app.asar/node_modules/text-buffer/lib/display-layer.js:968:12 populateSpatialIndexIfNeeded
    /app.asar/node_modules/text-buffer/lib/display-layer.js:587:10 getScreenLineCount
    /app.asar/src/text-editor.js:929:32 module.exports.TextEditor.getScreenLineCount
    /packages/minimap/lib/minimap.js:554:28 getHeight
    ...
```

The problem is that we're calling `Array.splice` with a large number of arguments.  We cap the argument count at 100,000, which was an attempt to avoid stack overflows, but depending on how many stack frames deep we are when calling `DisplayLayer.updateSpatialIndex`, and the size of those stack frames, this cap may still be too high.

The largest splice that I can perform in the dev tools is 125,000. So I think this error may have emerged in 1.14.0 because we are calling `splice` with 100,000 elements in a slightly deeper stack frame than before. `updateSpatialIndex` is also a pretty hefty stack frame, because it has a ton of local variables.

I've fixed this problem by rewriting `spliceArray` to not use `Array.splice` at all. We now move the items that follow the splice using an explicit loop, and then write the new items into place with another explicit loop. There's less native code being used this way, but we also avoid several large allocations, because we used to repeatedly `slice` the inserted array, and `Array.splice` also *returns* an array of removed items that we weren't using.

/cc @nathansobo