### PR TITLE
Verify valid state after updating spatial index

### DIFF
--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -971,7 +971,7 @@ class DisplayLayer {
       const expectedEndPosition = this.buffer.getEndPosition()
       if (!translatedEndPosition.isEqual(expectedEndPosition)) {
         global.atom.assert(false, 'Invalid spatial index state', {
-          lastScreenRow, lastScreenColumn, translatedEndPosition, expectedEndPosition,
+          lastScreenRow, lastScreenColumn, translatedEndPosition, expectedEndPosition
         })
       }
     }


### PR DESCRIPTION
⚠️  In order for this to work on `1.14-releases`, we'll need to cherry-pick https://github.com/atom/atom/commit/2ad6f832394e5160a354407680ee9aa8686d748a to that branch. ⚠️ 

We're seeing some rare exceptions in production that seemed to be caused by the spatial index getting into an invalid state, where it implies the existence of rows beyond the end of the last buffer row. This carries a cost but we want to find out if and when this is happening in production.

/cc @maxbrunsfeld