### PR TITLE
Introduce option to track marker destruction during onDidCreateMarker callbacks

### DIFF
--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -274,3 +274,27 @@ describe "MarkerLayer", ->
       # Markers states are updated regardless of whether they have an
       # ::onDidDestroy listener
       expect(marker2.isDestroyed()).toBe(true)
+
+  describe "trackDestructionInOnDidCreateMarkerCallbacks", ->
+    it "stores a stack trace when destroy is called during onDidCreateMarker callbacks", ->
+      layer1.onDidCreateMarker (m) -> m.destroy() if destroyInCreateCallback
+
+      layer1.trackDestructionInOnDidCreateMarkerCallbacks = true
+      destroyInCreateCallback = true
+      marker1 = layer1.markPosition([0, 0])
+      expect(marker1.isDestroyed()).toBe(true)
+      expect(marker1.destroyStackTrace).toBeDefined()
+
+      destroyInCreateCallback = false
+      marker2 = layer1.markPosition([0, 0])
+      expect(marker2.isDestroyed()).toBe(false)
+      expect(marker2.destroyStackTrace).toBeUndefined()
+      marker2.destroy()
+      expect(marker2.isDestroyed()).toBe(true)
+      expect(marker2.destroyStackTrace).toBeUndefined()
+
+      destroyInCreateCallback = true
+      layer1.trackDestructionInOnDidCreateMarkerCallbacks = false
+      marker3 = layer1.markPosition([0, 0])
+      expect(marker3.isDestroyed()).toBe(true)
+      expect(marker3.destroyStackTrace).toBeUndefined()

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -375,7 +375,9 @@ class MarkerLayer
     @delegate.markerCreated(this, marker)
     @delegate.markersUpdated(this)
     @scheduleUpdateEvent()
+    marker.trackDestruction = @trackDestructionInOnDidCreateMarkerCallbacks ? false
     @emitter.emit 'did-create-marker', marker if @emitCreateMarkerEvents
+    marker.trackDestruction = false
     marker
 
   ###

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -292,6 +292,12 @@ class Marker
   # Public: Destroys the marker, causing it to emit the 'destroyed' event.
   destroy: ->
     return if @isDestroyed()
+
+    if @trackDestruction
+      error = new Error
+      Error.captureStackTrace(error)
+      @destroyStackTrace = error.stack
+
     @layer.destroyMarker(this)
     @emitter.emit 'did-destroy'
     @emitter.clear()


### PR DESCRIPTION
This will help us debug stack traces that look like this that we're seeing in production.

```
Error Cannot decorate a destroyed marker 
    /app.asar/src/decoration-manager.js:192:15 module.exports.DecorationManager.decorateMarker
    /app.asar/src/text-editor.js:1686:37 module.exports.TextEditor.decorateMarker
    /app.asar/src/text-editor.js:2055:12 module.exports.TextEditor.addCursor
    /app.asar/src/text-editor.js:2550:21 module.exports.TextEditor.addSelection
    /app.asar/node_modules/text-buffer/lib/display-marker-layer.js:77:18 none
    /app.asar/node_modules/event-kit/lib/emitter.js:25:14 module.exports.Emitter.simpleDispatch
    /app.asar/node_modules/event-kit/lib/emitter.js:129:28 module.exports.Emitter.emit
    /app.asar/node_modules/text-buffer/lib/marker-layer.js:411:22 module.exports.MarkerLayer.createMarker
    /app.asar/node_modules/text-buffer/lib/marker-layer.js:211:19 module.exports.MarkerLayer.markRange
    /app.asar/node_modules/text-buffer/lib/display-marker-layer.js:103:62 module.exports.DisplayMarkerLayer.markBufferRange
    /app.asar/src/text-editor.js:2235:34 module.exports.TextEditor.addSelectionForBufferRange
    /app.asar/src/text-editor.js:2613:21 module.exports.TextEditor.createLastSelectionIfNeeded
    /app.asar/src/text-editor.js:2013:12 module.exports.TextEditor.getLastCursor
    /app.asar/src/text-editor-presenter.js:334:37 module.exports.TextEditorPresenter.updateHiddenInputState
    /app.asar/src/text-editor-presenter.js:145:12 module.exports.TextEditorPresenter.getPostMeasurementState
    /app.asar/src/text-editor-component.js:202:38 module.exports.TextEditorComponent.updateSync
    /app.asar/src/text-editor-component.js:303:21 module.exports.TextEditorComponent.becameVisible
    /app.asar/src/text-editor-component.js:994:16 module.exports.TextEditorComponent.checkForVisibilityChange
    /app.asar/src/text-editor-component.js:980:17 module.exports.TextEditorComponent.pollDOM
    /app.asar/src/text-editor-component.js:3:59 none
    /app.asar/src/view-registry.js:263:9 module.exports.ViewRegistry.performDocumentPoll
    /app.asar/src/view-registry.js:226:14 module.exports.ViewRegistry.performDocumentUpdate
    /app.asar/src/view-registry.js:3:59 none
```