### PR TITLE
Fix preceding boundary calculation for changes inside of folds

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -528,6 +528,21 @@ describe('DisplayLayer', () => {
         }
       }
     })
+
+    it('correctly updates the index for edits fully contained within multi-line folds that appear on soft-wrapped line segments', () => {
+      const buffer = new TextBuffer({
+        text: 'premillennial alcoholism\nelse\t\nastraphobia stereotomy\nbananas\n'
+      })
+      const displayLayer = buffer.addDisplayLayer({
+        tabLength: 4,
+        invisibles: {eol: '¬'},
+        softWrapColumn: 10
+      })
+      displayLayer.foldBufferRange([[0, 16], [1, 4]])
+      displayLayer.foldBufferRange([[1, 5], [3, 3]])
+      buffer.setTextInRange([[2, 16], [2, 21]], ' \nunderlinen\ncopybook\t')
+      expect(displayLayer.getText()).toBe('premillenn\nial al⋯ \n⋯anas¬\n')
+    })
   })
 
   describe('soft wraps', () => {

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -999,16 +999,13 @@ class DisplayLayer {
 
   findBoundaryPrecedingBufferRow (bufferRow) {
     while (true) {
+      if (bufferRow === 0) return 0
       let screenPosition = this.translateBufferPositionWithSpatialIndex(Point(bufferRow, 0), 'backward')
-      if (screenPosition.column === 0) {
-        return this.translateScreenPositionWithSpatialIndex(screenPosition, 'backward').row
+      let bufferPosition = this.translateScreenPositionWithSpatialIndex(Point(screenPosition.row, 0), 'backward', false)
+      if (screenPosition.column === 0 && bufferPosition.column === 0) {
+        return bufferPosition.row
       } else {
-        let bufferPosition = this.translateScreenPositionWithSpatialIndex(Point(screenPosition.row, 0), 'backward', false)
-        if (bufferPosition.column === 0) {
-          return bufferPosition.row
-        } else {
-          bufferRow = bufferPosition.row
-        }
+        bufferRow = bufferPosition.row
       }
     }
   }


### PR DESCRIPTION
If a change is inside a fold and that fold appears at the beginning of a soft-wrapped line segment, we need to continue iterating upward in our search for a line boundary. Previously we would stop because the screen column was 0, but that is invalid if the beginning of the buffer row isn't on screen due to being folded.

We also think the new logic in `findBoundaryPrecedingBufferRow` expresses the intent of the method more clearly now.

:pear:d with @as-cii

/cc @maxbrunsfeld 