### PR TITLE
Re-expand tabs on wrapped lines after inserting soft-wraps

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -848,15 +848,15 @@ describe('DisplayLayer', () => {
 
     it('re-expands tabs on soft-wrapped lines', () => {
       const buffer = new TextBuffer({
-        text: 'ab cd\t   '
+        text: 'fah\t\t\tcodexelectric valence\t ble'
       })
 
       const displayLayer = buffer.addDisplayLayer({
         tabLength: 4,
-        softWrapColumn: 10
+        softWrapColumn: 12
       })
 
-      expect(JSON.stringify(displayLayer.getText())).toBe(JSON.stringify('ab \ncd     '))
+      displayLayer.getText()
       expect(displayLayer.indexedBufferRowCount).toBe(buffer.getLineCount())
       verifyLineLengths(displayLayer)
     })

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -846,6 +846,21 @@ describe('DisplayLayer', () => {
       expect(JSON.stringify(displayLayer.getText())).toBe(JSON.stringify('abc \ndef     '))
     })
 
+    it('re-expands tabs on soft-wrapped lines', () => {
+      const buffer = new TextBuffer({
+        text: 'ab cd\t   '
+      })
+
+      const displayLayer = buffer.addDisplayLayer({
+        tabLength: 4,
+        softWrapColumn: 10
+      })
+
+      expect(JSON.stringify(displayLayer.getText())).toBe(JSON.stringify('ab \ncd     '))
+      expect(displayLayer.indexedBufferRowCount).toBe(buffer.getLineCount())
+      verifyLineLengths(displayLayer)
+    })
+
     it('correctly soft wraps lines when hard tabs are wider than the softWrapColumn', () => {
       const buffer = new TextBuffer({
         text: '\they'

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -879,10 +879,11 @@ class DisplayLayer {
               expandedScreenColumnAfterLastTab += (tabColumnAfterWrap - unexpandedScreenColumnAfterLastTab)
               expandedScreenColumnAfterLastTab += this.tabLength - (expandedScreenColumnAfterLastTab % this.tabLength)
               unexpandedScreenColumnAfterLastTab = tabColumnAfterWrap + 1
+              currentScreenLineTabColumns[i - tabCountPrecedingWrap] = tabColumnAfterWrap
             }
           }
           insertedTabCounts.push(tabCountPrecedingWrap)
-          currentScreenLineTabColumns.splice(0, tabCountPrecedingWrap)
+          currentScreenLineTabColumns.length -= tabCountPrecedingWrap
 
           unexpandedScreenColumn = unexpandedScreenColumn - unexpandedWrapColumn + indentLength
           expandedScreenColumn = expandedScreenColumnAfterLastTab + unexpandedScreenColumn - unexpandedScreenColumnAfterLastTab


### PR DESCRIPTION
This fixes a rare randomized test failure @nathansobo found running them overnight.