### PR TITLE
Emit marker layer update events synchronously at end of next transaction

### DIFF
--- a/spec/display-marker-layer-spec.coffee
+++ b/spec/display-marker-layer-spec.coffee
@@ -147,6 +147,7 @@ describe "DisplayMarkerLayer", ->
     buffer = new TextBuffer(text: 'hello world')
     displayLayer = buffer.addDisplayLayer(tabLength: 4)
     markerLayer = displayLayer.addMarkerLayer()
+    marker = null
 
     updateEventCount = 0
     markerLayer.onDidUpdate ->
@@ -160,7 +161,8 @@ describe "DisplayMarkerLayer", ->
       else if updateEventCount is 4
         done()
 
-    marker = markerLayer.markScreenRange([[0, 4], [1, 4]])
+    buffer.transact ->
+      marker = markerLayer.markScreenRange([[0, 4], [1, 4]])
 
   it "allows markers to be copied", ->
     buffer = new TextBuffer(text: '\ta\tbc\tdef\tg\n\th')


### PR DESCRIPTION
Previously, marker layer update events were emitted asynchronously in a `nextTick` callback to coalesce multiple marker updates into a single event. Unfortunately, this creates challenges writing rendering code for the editor because async animation frame requests interact in unpredictable ways with the next tick and make tests brittle. Async layer events also create a redundant update immediately following editor creation due to the cursors getting added. Keeping things sync simplifies code that subscribes to these events, while waiting until the end of the next transaction gives us tools to prevent these events from firing too frequently.

/cc @maxbrunsfeld @as-cii 