### PR TITLE
Always update display layer before emitting a marker layer update event

### DIFF
--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -179,6 +179,9 @@ describe "MarkerLayer", ->
     it "notifies observers at the end of the outermost transaction when markers are created, updated, or destroyed", ->
       [marker1, marker2] = []
 
+      displayLayer = buffer.addDisplayLayer()
+      displayLayerDidChange = false
+
       updateCount = 0
       layer1.onDidUpdate ->
         updateCount++
@@ -193,6 +196,8 @@ describe "MarkerLayer", ->
         else if updateCount is 3
           marker1.destroy()
           marker2.destroy()
+        else if updateCount is 6
+          expect(displayLayerDidChange).toBe(true, 'Display layer was updated after marker layer.')
 
       buffer.transact ->
         buffer.transact ->
@@ -204,6 +209,12 @@ describe "MarkerLayer", ->
       # update events happen immediately when there is no parent transaction
       layer1.markRange([[0, 2], [0, 4]])
       expect(updateCount).toBe(5)
+
+      # update events happen after updating display layers when there is no parent transaction.
+      displayLayer.onDidChangeSync ->
+        displayLayerDidChange = true
+      buffer.undo()
+      expect(updateCount).toBe(6)
 
   describe "::clear()", ->
     it "destroys all of the layer's markers", (done) ->

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -272,7 +272,6 @@ class MarkerLayer
           marker.destroy()
         else
           marker.valid = false
-    @delegate.markersUpdated(this)
 
   restoreFromSnapshot: (snapshots) ->
     return unless snapshots?


### PR DESCRIPTION
Previously, when a change was happening outside of a transaction (e.g. undo, redo, etc.), we were emitting a marker layer update event as soon as we spliced each marker layer. This was causing display layers to be out of date when the marker layer event occurred and could therefore cause problems if users performed a display layer query display layer inside the update event.

With this commit, marker layer update events will now always be emitted after updating display layers, thus fixing the errors we were observing in Atom (https://circleci.com/gh/atom/atom/2806).

/cc: @nathansobo 