### PR TITLE
make one test fail to check Travis status

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -26,7 +26,7 @@ describe "TextBuffer", ->
   describe "construction", ->
     it "can be constructed empty", ->
       buffer = new TextBuffer
-      expect(buffer.getLineCount()).toBe 1
+      expect(buffer.getLineCount()).toBe 2
       expect(buffer.getText()).toBe ''
       expect(buffer.lineForRow(0)).toBe ''
       expect(buffer.lineEndingForRow(0)).toBe ''


### PR DESCRIPTION
**Do not merge this**

Just to check the Travis status when a spec is failing. See https://github.com/atom/text-buffer/pull/195#issuecomment-284924359