### PR TITLE
Clear cached screen lines correctly when range invalidation events occur

### DIFF
--- a/script/test
+++ b/script/test
@@ -40,5 +40,5 @@ normalizeCommand = (command) => {
 if (argv.interactive) {
   childProcess.spawnSync(normalizeCommand('./node_modules/.bin/electron'), ['spec/support/runner', 'spec/**/*-spec.*'], {stdio: 'inherit', cwd: path.join(__dirname, '..')})
 } else {
-  process.exit(childProcess.spawnSync(normalizeCommand('./node_modules/.bin/jasmine'), ['--captureExceptions', '--forceexit', '--stop-on-failure=true'], {stdio: 'inherit'}).status)
+  process.exit(childProcess.spawnSync(normalizeCommand('./node_modules/.bin/jasmine'), ['--stop-on-failure=true'], {stdio: 'inherit'}).status)
 }

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -1938,9 +1938,9 @@ describe('DisplayLayer', () => {
       decorationLayer.emitInvalidateRangeEvent([[2, 1], [3, 2]])
 
       expect(allChanges).toEqual([{
-        start: Point(1, 5),
-        oldExtent: Point(1, 2),
-        newExtent: Point(1, 2)
+        start: Point(1, 0),
+        oldExtent: Point(2, 0),
+        newExtent: Point(2, 0)
       }])
     })
 
@@ -2261,6 +2261,8 @@ describe('DisplayLayer', () => {
             undoableChanges++
             redoableChanges--
             performRedo(random, displayLayer)
+          } else if (k < 8) {
+            textDecorationLayer.emitInvalidateRangeEvent(getRandomBufferRange(random, buffer))
           } else {
             undoableChanges++
             performRandomChange(random, displayLayer)

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -143,16 +143,16 @@ class DisplayLayer {
     this.textDecorationLayer = textDecorationLayer
     if (typeof textDecorationLayer.onDidInvalidateRange === 'function') {
       this.decorationLayerDisposable = textDecorationLayer.onDidInvalidateRange((bufferRange) => {
-        const screenRange = this.translateBufferRange(bufferRange)
-        const extent = screenRange.getExtent()
-        spliceArray(
-          this.cachedScreenLines,
-          screenRange.start.row,
-          extent.row + 1,
-          new Array(extent.row + 1)
-        )
+        bufferRange = Range.fromObject(bufferRange)
+        this.populateSpatialIndexIfNeeded(bufferRange.end.row + 1, Infinity)
+        const startBufferRow = this.findBoundaryPrecedingBufferRow(bufferRange.start.row)
+        const endBufferRow = this.findBoundaryFollowingBufferRow(bufferRange.end.row + 1)
+        const startRow = this.translateBufferPositionWithSpatialIndex(Point(startBufferRow, 0), 'backward').row
+        const endRow = this.translateBufferPositionWithSpatialIndex(Point(endBufferRow, 0), 'backward').row
+        const extent = Point(endRow - startRow, 0)
+        spliceArray(this.cachedScreenLines, startRow, extent.row, new Array(extent.row))
         this.emitDidChangeSyncEvent([{
-          start: screenRange.start,
+          start: Point(startRow, 0),
           oldExtent: extent,
           newExtent: extent
         }])


### PR DESCRIPTION
Previously, we were mistakenly translating the buffer range to screen coordinates and invalidating all the cached lines located at that screen range. This, however, could lead to emitting duplicate lines when folds or soft wrap occurred at the given invalidation range.

With this pull request we will find the line boundaries preceding and following the given buffer range, and splice the screen lines corresponding to those buffer rows instead.

/cc: @nathansobo @maxbrunsfeld 