### PR TITLE
Don't notify observers of `onDidChangeText` after an empty transaction

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2650,7 +2650,6 @@ describe "TextBuffer", ->
         buffer.insert([2, 3], "zw")
         buffer.delete([[2, 3], [2, 4]])
 
-
       assertChangesEqual(textChanges, [
         {
           oldRange: [[1, 0], [1, 0]],
@@ -2714,6 +2713,12 @@ describe "TextBuffer", ->
           newText: "j",
         }
       ])
+
+    it "doesn't notify observers after an empty transaction", ->
+      didChangeTextSpy = jasmine.createSpy()
+      buffer.onDidChangeText(didChangeTextSpy)
+      buffer.transact(->)
+      expect(didChangeTextSpy).not.toHaveBeenCalled()
 
     it "doesn't throw an error when clearing the undo stack within a transaction", ->
       buffer.onDidChangeText(didChangeTextSpy = jasmine.createSpy())

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1654,9 +1654,11 @@ class TextBuffer
   emitDidChangeTextEvent: (patch) ->
     return if @transactCallDepth isnt 0
 
-    @emitter.emit 'did-change-text', {changes: Object.freeze(normalizePatchChanges(patch.getHunks()))}
-    @patchesSinceLastStoppedChangingEvent.push(patch)
-    @scheduleDidStopChangingEvent()
+    hunks = patch.getHunks()
+    if hunks.length > 0
+      @emitter.emit 'did-change-text', {changes: Object.freeze(normalizePatchChanges(hunks))}
+      @patchesSinceLastStoppedChangingEvent.push(patch)
+      @scheduleDidStopChangingEvent()
 
   # Identifies if the buffer belongs to multiple editors.
   #


### PR DESCRIPTION
In Atom we are using transactions to emit a single `onDidUpdate` event on marker layers when multiple markers are manually moved at the same time. 

Previously, even when not making any changes to the buffer during one of these transactions, we would emit an `onDidChangeText` event with an empty list of changed regions.  Packages could, however, rely on this event to perform destructive actions, and that should not happen as a result of a simple cursor movement. This was causing some test failures in https://github.com/atom/atom/pull/12696.

For this reason, with this pull request we are changing the `onDidChangeText` event to be emitted only when the buffer is modified.

/cc: @nathansobo 
