### PR TITLE
Clear rightmost screen position when resetting a display layer

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -54,15 +54,23 @@ describe('DisplayLayer', () => {
 
   describe('reset()', () => {
     it('updates the screen lines to reflect the new parameters', () => {
-      const buffer = new TextBuffer({
-        text: 'abc def\nghi jkl\nmno pqr'
-      })
-
+      const buffer = new TextBuffer({text: 'abc def\nghi jkl\nmno pqr'})
       const displayLayer = buffer.addDisplayLayer({})
       expect(displayLayer.translateScreenPosition(Point(1, 3))).toEqual(Point(1, 3))
 
       displayLayer.reset({softWrapColumn: 4})
       expect(displayLayer.translateScreenPosition(Point(1, 3))).toEqual(Point(0, 7))
+    })
+
+    it('resets the rightmost screen position', () => {
+      const buffer = new TextBuffer({text: 'abc def\nghi jkl\nmnopqrst'})
+      const displayLayer = buffer.addDisplayLayer({softWrapColumn: 5})
+      expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(0, 0))
+      expect(displayLayer.getRightmostScreenPosition()).toEqual(Point(4, 5))
+
+      displayLayer.reset({softWrapColumn: 4})
+      expect(displayLayer.getApproximateRightmostScreenPosition()).toEqual(Point(0, 0))
+      expect(displayLayer.getRightmostScreenPosition()).toEqual(Point(0, 4))
     })
   })
 

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -128,6 +128,7 @@ class DisplayLayer {
     this.cachedScreenLines.length = 0
     this.screenLineLengths.length = 0
     this.tabCounts.length = 0
+    this.rightmostScreenPosition = Point(0, 0)
   }
 
   doBackgroundWork (deadline) {


### PR DESCRIPTION
Previously, we would keep the stored rightmost screen position even after a display layer instance had been reset. This was causing issues in https://github.com/atom/atom/pull/13880 because sometimes it caused inexistent screen lines to be measured, thus making Atom throw exceptions.

/cc: @nathansobo 