### PR TITLE
Optimize critical code paths and add displayLayer.bufferRowsForScreenRows

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -2193,6 +2193,27 @@ describe('DisplayLayer', () => {
     })
   })
 
+  describe('.bufferRowsForScreenRows(startRow, endRow)', () => {
+    it('returns an array containing the buffer rows for the given screen row range', () => {
+      const buffer = new TextBuffer({text: 'abcde\nfghij\nklmno\npqrst\nuvwxyz'})
+      const displayLayer = buffer.addDisplayLayer({softWrapColumn: 4})
+      const fold1 = displayLayer.foldBufferRange([[0, 1], [1, 1]])
+      const fold2 = displayLayer.foldBufferRange([[2, 2], [3, 2]])
+      const fold3 = displayLayer.foldBufferRange([[3, 3], [3, 4]])
+
+      expect(displayLayer.bufferRowsForScreenRows(2, 5)).toEqual([2, 3, 4])
+      expect(displayLayer.bufferRowsForScreenRows(3, 5)).toEqual([3, 4])
+      expect(displayLayer.bufferRowsForScreenRows(4, 6)).toEqual([4, 4])
+      expect(displayLayer.bufferRowsForScreenRows(0, 7)).toEqual([0, 1, 2, 3, 4, 4, 5])
+
+      displayLayer.destroyFold(fold2)
+      expect(displayLayer.bufferRowsForScreenRows(2, 5)).toEqual([2, 2, 3])
+      expect(displayLayer.bufferRowsForScreenRows(3, 5)).toEqual([2, 3])
+      expect(displayLayer.bufferRowsForScreenRows(4, 6)).toEqual([3, 3])
+      expect(displayLayer.bufferRowsForScreenRows(0, 8)).toEqual([0, 1, 2, 2, 3, 3, 4, 4])
+    })
+  })
+
   describe('.getScreenLines(startRow, endRow)', () => {
     it('returns an empty array when the given start row is greater than the screen line count', () => {
       const buffer = new TextBuffer({

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -2197,9 +2197,9 @@ describe('DisplayLayer', () => {
     it('returns an array containing the buffer rows for the given screen row range', () => {
       const buffer = new TextBuffer({text: 'abcde\nfghij\nklmno\npqrst\nuvwxyz'})
       const displayLayer = buffer.addDisplayLayer({softWrapColumn: 4})
-      const fold1 = displayLayer.foldBufferRange([[0, 1], [1, 1]])
+      const fold1 = displayLayer.foldBufferRange([[0, 1], [1, 1]]) // eslint-disable-line no-unused-vars
       const fold2 = displayLayer.foldBufferRange([[2, 2], [3, 2]])
-      const fold3 = displayLayer.foldBufferRange([[3, 3], [3, 4]])
+      const fold3 = displayLayer.foldBufferRange([[3, 3], [3, 4]]) // eslint-disable-line no-unused-vars
 
       expect(displayLayer.bufferRowsForScreenRows(2, 5)).toEqual([2, 3, 4])
       expect(displayLayer.bufferRowsForScreenRows(3, 5)).toEqual([3, 4])

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -530,12 +530,12 @@ class DisplayLayer {
   }
 
   getClipColumnDelta (bufferPosition, clipDirection) {
-    const {row: bufferRow, column: bufferColumn} = bufferPosition
-    const bufferLine = this.buffer.lineForRow(bufferRow)
+    var {row: bufferRow, column: bufferColumn} = bufferPosition
+    var bufferLine = this.buffer.lineForRow(bufferRow)
 
     // Treat paired unicode characters as atomic...
-    const previousCharacter = bufferLine[bufferColumn - 1]
-    const character = bufferLine[bufferColumn]
+    var previousCharacter = bufferLine[bufferColumn - 1]
+    var character = bufferLine[bufferColumn]
     if (previousCharacter && character && isCharacterPair(previousCharacter, character)) {
       if (clipDirection === 'closest' || clipDirection === 'backward') {
         return -1
@@ -556,9 +556,9 @@ class DisplayLayer {
       if (bufferLine[column] !== ' ') return 0
     }
 
-    const previousTabStop = bufferColumn - (bufferColumn % this.tabLength)
+    var previousTabStop = bufferColumn - (bufferColumn % this.tabLength)
     if (bufferColumn === previousTabStop) return 0
-    const nextTabStop = previousTabStop + this.tabLength
+    var nextTabStop = previousTabStop + this.tabLength
 
     // If there is a non-whitespace character before the next tab stop,
     // don't this whitespace as a soft tab
@@ -566,7 +566,7 @@ class DisplayLayer {
       if (bufferLine[column] !== ' ') return 0
     }
 
-    let clippedColumn
+    var clippedColumn
     if (clipDirection === 'closest') {
       if (bufferColumn - previousTabStop > this.tabLength / 2) {
         clippedColumn = nextTabStop

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -629,11 +629,10 @@ class DisplayLayer {
     this.populateSpatialIndexIfNeeded(this.buffer.getLineCount(), endRow)
 
     const startPosition = Point(startRow, 0)
-    const endPosition = Point(endRow, 0)
     const bufferRows = []
     let lastScreenRow = startRow
     let lastBufferRow = this.translateScreenPositionWithSpatialIndex(startPosition).row
-    const hunks = this.spatialIndex.getHunksInNewRange(startPosition, endPosition)
+    const hunks = this.spatialIndex.getHunksInNewRange(startPosition, Point(endRow, 0))
     for (let i = 0; i < hunks.length; i++) {
       const hunk = hunks[i]
       while (lastScreenRow <= hunk.newStart.row) {

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -723,11 +723,11 @@ class DisplayLayer {
   }
 
   isOpenTag (tag) {
-    return tag < 0 && tag % 2 === -1
+    return tag < 0 && (tag & 1) === 1
   }
 
   isCloseTag (tag) {
-    return tag < 0 && tag % 2 === 0
+    return tag < 0 && (tag & 1) === 0
   }
 
   bufferWillChange (change) {

--- a/src/screen-line-builder.js
+++ b/src/screen-line-builder.js
@@ -29,9 +29,9 @@ class ScreenLineBuilder {
 
     endScreenRow = this.displayLayer.findBoundaryFollowingScreenRow(endScreenRow)
 
-    let decorationIterator
-    const hunks = this.displayLayer.spatialIndex.getHunksInNewRange(Point(this.screenRow, 0), Point(endScreenRow, 0))
-    let hunkIndex = 0
+    var decorationIterator
+    var hunks = this.displayLayer.spatialIndex.getHunksInNewRange(Point(this.screenRow, 0), Point(endScreenRow, 0))
+    var hunkIndex = 0
 
     this.containingScopeIds = []
     this.scopeIdsToReopen = []
@@ -44,7 +44,7 @@ class ScreenLineBuilder {
     // buffer.
     screenRowLoop:
     while (this.screenRow < endScreenRow) {
-      const cachedScreenLine = this.displayLayer.cachedScreenLines[this.screenRow]
+      var cachedScreenLine = this.displayLayer.cachedScreenLines[this.screenRow]
       if (cachedScreenLine) {
         this.pushScreenLine(cachedScreenLine)
 
@@ -89,7 +89,7 @@ class ScreenLineBuilder {
       // multiple screen rows if there are soft wraps.
       while (this.bufferColumn <= this.bufferLine.length) {
         // Handle folds or soft wraps at the current position.
-        let nextHunk = hunks[hunkIndex]
+        var nextHunk = hunks[hunkIndex]
         while (nextHunk && nextHunk.oldStart.row === this.bufferRow && nextHunk.oldStart.column === this.bufferColumn) {
           if (this.displayLayer.isSoftWrapHunk(nextHunk)) {
             this.emitSoftWrap(nextHunk)
@@ -101,7 +101,7 @@ class ScreenLineBuilder {
           nextHunk = hunks[hunkIndex]
         }
 
-        const nextCharacter = this.bufferLine[this.bufferColumn]
+        var nextCharacter = this.bufferLine[this.bufferColumn]
         if (this.bufferColumn >= this.trailingWhitespaceStartColumn) {
           this.inTrailingWhitespace = true
           this.inLeadingWhitespace = false
@@ -111,7 +111,7 @@ class ScreenLineBuilder {
 
         // Compute a token flags describing built-in decorations for the token
         // containing the next character
-        const previousBuiltInTagFlags = this.currentBuiltInClassNameFlags
+        var previousBuiltInTagFlags = this.currentBuiltInClassNameFlags
         this.updateCurrentTokenFlags(nextCharacter)
 
         if (this.emitBuiltInTagBoundary) {
@@ -210,12 +210,12 @@ class ScreenLineBuilder {
 
   emitDecorationBoundaries (decorationIterator) {
     while (this.compareBufferPosition(decorationIterator.getPosition()) === 0) {
-      const closeScopeIds = decorationIterator.getCloseScopeIds()
+      var closeScopeIds = decorationIterator.getCloseScopeIds()
       for (let i = 0, n = closeScopeIds.length; i < n; i++) {
         this.emitCloseTag(closeScopeIds[i])
       }
 
-      const openScopeIds = decorationIterator.getOpenScopeIds()
+      var openScopeIds = decorationIterator.getOpenScopeIds()
       for (let i = 0, n = openScopeIds.length; i < n; i++) {
         this.emitOpenTag(openScopeIds[i])
       }
@@ -359,7 +359,7 @@ class ScreenLineBuilder {
 
     this.emitEmptyTokenIfNeeded()
 
-    let containingScopeId
+    var containingScopeId
     while ((containingScopeId = this.containingScopeIds.pop())) {
       this.currentScreenLineTags.push(this.displayLayer.closeTagForScopeId(containingScopeId))
       if (containingScopeId === scopeId) {

--- a/src/screen-line-builder.js
+++ b/src/screen-line-builder.js
@@ -406,18 +406,7 @@ class ScreenLineBuilder {
   }
 
   compareBufferPosition (position) {
-    if (this.bufferRow < position.row) {
-      return -1
-    } else if (this.bufferRow === position.row) {
-      if (this.bufferColumn < position.column) {
-        return -1
-      } else if (this.bufferColumn === position.column) {
-        return 0
-      } else {
-        return 1
-      }
-    } else {
-      return 1
-    }
+    const rowComparison = this.bufferRow - position.row
+    return rowComparison === 0 ? (this.bufferColumn - position.column) : rowComparison
   }
 }


### PR DESCRIPTION
This pull request addresses multiple concerns in the critical rendering code path:

1. Uses bitwise operations as opposed to modulo arithmetic to determine if numbers are odd or even.
2. Improves the performance of `compareBufferPosition` in ScreenLineBuilder by performing only one comparison and using subtraction instead.
3. Avoids de-optimized code paths due to "Unsupported phi use of const or let", replacing usages of `const` or `let` with `var`.
4. Adds a `DisplayLayer.prototype.bufferRowsForScreenRows` method that efficiently queries the spatial index to report every buffer row in the given screen row range.

/cc: @nathansobo 