### PR TITLE
Don't reset the "did-stop-changing" timeout for each buffer change

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,6 +8,25 @@ exports.regexIsSingleLine = function (regex) {
   return !MULTI_LINE_REGEX_REGEX.test(regex.source)
 }
 
+exports.debounce = function debounce (fn, wait) {
+  let timestamp, timeout
+
+  function later () {
+    const last = Date.now() - timestamp
+    if (last < wait && last >= 0) {
+      timeout = setTimeout(later, wait - last)
+    } else {
+      timeout = null
+      fn()
+    }
+  }
+
+  return function () {
+    timestamp = Date.now()
+    if (!timeout) timeout = setTimeout(later, wait)
+  }
+}
+
 exports.spliceArray = function (array, start, removedCount, insertedItems = []) {
   const oldLength = array.length
   const insertedCount = insertedItems.length


### PR DESCRIPTION
Instead, use a smarter debounce function that always waits for the existing timeout to fire and, if the buffer has changed in the meantime, schedules a new one.

/cc: @nathansobo 