### PR TITLE
Ensure `patch != null` before accessing it in `finishLoading`

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1685,7 +1685,7 @@ class TextBuffer
     @digestWhenLastPersisted = @buffer.baseTextDigest()
     @cachedText = null
 
-    if @loaded and patch.getChangeCount() > 0
+    if @loaded and patch and patch.getChangeCount() > 0
       if options?.clearHistory
         @history.clearUndoStack()
       else


### PR DESCRIPTION
This fixes a `Cannot read property 'getChangeCount' of null` error that we are observing while running tests. It feels like this is an error that could manifest in production as well, but I am not 100% sure.

/cc: @maxbrunsfeld 