### PR TITLE
Emit marker layer update events at the end of the outermost transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.0.5",
+  "version": "13.0.6-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -182,21 +182,29 @@ describe "MarkerLayer", ->
       displayLayer = buffer.addDisplayLayer()
       displayLayerDidChange = false
 
+      changeCount = 0
+      buffer.onDidChangeText ->
+        changeCount++
+
       updateCount = 0
       layer1.onDidUpdate ->
         updateCount++
         if updateCount is 1
+          expect(changeCount).toBe(0)
           buffer.transact ->
             marker1.setRange([[1, 2], [3, 4]])
             marker2.setRange([[4, 5], [6, 7]])
         else if updateCount is 2
+          expect(changeCount).toBe(0)
           buffer.transact ->
             buffer.insert([0, 1], "xxx")
             buffer.insert([0, 1], "yyy")
         else if updateCount is 3
+          expect(changeCount).toBe(1)
           marker1.destroy()
           marker2.destroy()
-        else if updateCount is 6
+        else if updateCount is 7
+          expect(changeCount).toBe(2)
           expect(displayLayerDidChange).toBe(true, 'Display layer was updated after marker layer.')
 
       buffer.transact ->
@@ -204,17 +212,17 @@ describe "MarkerLayer", ->
           marker1 = layer1.markRange([[0, 2], [0, 4]])
           marker2 = layer1.markRange([[0, 6], [0, 8]])
 
-      expect(updateCount).toBe(4)
+      expect(updateCount).toBe(5)
 
       # update events happen immediately when there is no parent transaction
       layer1.markRange([[0, 2], [0, 4]])
-      expect(updateCount).toBe(5)
+      expect(updateCount).toBe(6)
 
       # update events happen after updating display layers when there is no parent transaction.
       displayLayer.onDidChangeSync ->
         displayLayerDidChange = true
       buffer.undo()
-      expect(updateCount).toBe(6)
+      expect(updateCount).toBe(7)
 
   describe "::clear()", ->
     it "destroys all of the layer's markers", (done) ->

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -282,15 +282,13 @@ class MarkerLayer
     for id in snapshotIds
       snapshot = snapshots[id]
       if marker = @markersById[id]
-        marker.update(marker.getRange(), snapshot, true)
+        marker.update(marker.getRange(), snapshot, true, true)
       else
-        newMarker = @createMarker(snapshot.range, snapshot)
+        newMarker = @createMarker(snapshot.range, snapshot, true)
 
     for id in existingMarkerIds
       if (marker = @markersById[id]) and (not snapshots[id]?)
-        marker.destroy()
-
-    @delegate.markersUpdated(this)
+        marker.destroy(true)
 
   createSnapshot: ->
     result = {}
@@ -331,14 +329,14 @@ class MarkerLayer
   markerUpdated: ->
     @delegate.markersUpdated(this)
 
-  destroyMarker: (marker) ->
+  destroyMarker: (marker, suppressMarkerLayerUpdateEvents=false) ->
     if @markersById.hasOwnProperty(marker.id)
       delete @markersById[marker.id]
       @index.remove(marker.id)
       @markersWithChangeListeners.delete(marker)
       @markersWithDestroyListeners.delete(marker)
       @displayMarkerLayers.forEach (displayMarkerLayer) -> displayMarkerLayer.destroyMarker(marker.id)
-      @delegate.markersUpdated(this)
+      @delegate.markersUpdated(this) unless suppressMarkerLayerUpdateEvents
 
   hasMarker: (id) ->
     not @destroyed and @index.has(id)
@@ -365,11 +363,11 @@ class MarkerLayer
   setMarkerIsExclusive: (id, exclusive) ->
     @index.setExclusive(id, exclusive)
 
-  createMarker: (range, params) ->
+  createMarker: (range, params, suppressMarkerLayerUpdateEvents=false) ->
     id = @delegate.getNextMarkerId()
     marker = @addMarker(id, range, params)
     @delegate.markerCreated(this, marker)
-    @delegate.markersUpdated(this)
+    @delegate.markersUpdated(this) unless suppressMarkerLayerUpdateEvents
     marker.trackDestruction = @trackDestructionInOnDidCreateMarkerCallbacks ? false
     @emitter.emit 'did-create-marker', marker if @emitCreateMarkerEvents
     marker.trackDestruction = false

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -290,7 +290,7 @@ class Marker
     ))
 
   # Public: Destroys the marker, causing it to emit the 'destroyed' event.
-  destroy: ->
+  destroy: (suppressMarkerLayerUpdateEvents) ->
     return if @isDestroyed()
 
     if @trackDestruction
@@ -298,7 +298,7 @@ class Marker
       Error.captureStackTrace(error)
       @destroyStackTrace = error.stack
 
-    @layer.destroyMarker(this)
+    @layer.destroyMarker(this, suppressMarkerLayerUpdateEvents)
     @emitter.emit 'did-destroy'
     @emitter.clear()
 
@@ -340,7 +340,7 @@ class Marker
       else
         isEqual(@properties[key], value)
 
-  update: (oldRange, {range, reversed, tailed, valid, exclusive, properties}, textChanged=false) ->
+  update: (oldRange, {range, reversed, tailed, valid, exclusive, properties}, textChanged=false, suppressMarkerLayerUpdateEvents=false) ->
     return if @isDestroyed()
 
     wasExclusive = @isExclusive()
@@ -376,7 +376,7 @@ class Marker
       updated = true
 
     @emitChangeEvent(range ? oldRange, textChanged, propertiesChanged)
-    @layer.markerUpdated() if updated and not textChanged
+    @layer.markerUpdated() if updated and not suppressMarkerLayerUpdateEvents
     updated
 
   getSnapshot: (range) ->


### PR DESCRIPTION
Also, ensure that such events are delivered after notifying `onDidChangeText` subscribers.

/cc: @nathansobo for 👀 