### PR TITLE
Make sure TextBuffer.save() calls through to custom files

### DIFF
--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -239,8 +239,13 @@ describe('TextBuffer IO', () => {
     })
 
     describe('when the buffer is backed by a custom File object instead of a path', () => {
+      let file
+
       beforeEach(() => {
-        buffer.setFile(new SimpleFile(filePath))
+        buffer = new TextBuffer()
+        file = new SimpleFile(filePath)
+        buffer.setFile(file)
+        spyOn(file, 'createWriteStream').and.callThrough()
       })
 
       it('saves the contents of the buffer to the given file', (done) => {
@@ -248,6 +253,7 @@ describe('TextBuffer IO', () => {
         buffer.save().then(() => {
           expect(fs.readFileSync(filePath, 'utf8')).toEqual(buffer.getText())
           expect(buffer.isModified()).toBe(false)
+          expect(file.createWriteStream).toHaveBeenCalled()
           done()
         })
       })

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1552,7 +1552,7 @@ class TextBuffer
 
   saveTo: (file) ->
     if @destroyed then throw new Error("Can't save destroyed buffer")
-    unless file then throw new Error("Must provide a file to save")
+    unless file then throw new Error("Can't save a buffer with no file")
 
     filePath = file.getPath()
     if file instanceof File

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1539,7 +1539,7 @@ class TextBuffer
   #
   # Returns a {Promise} that resolves when the save has completed.
   save: ->
-    @saveAs(@getPath())
+    @saveTo(@file)
 
   # Public: Save the buffer at a specific path.
   #


### PR DESCRIPTION
The unit test didn't catch this since the path / file are otherwise identical 😆
I amended the test to actually ensure that `createWriteStream()` is being called.

Released under CC0.