### PR TITLE
Don't consider lone CRs as line breaks in setTextViaDiff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.0.8",
+  "version": "13.0.9-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1298,6 +1298,15 @@ describe "TextBuffer", ->
       buffer.setTextViaDiff(newText)
       expect(buffer.getText()).toBe newText
 
+    it "can change a buffer that contains lone carriage returns", ->
+      oldText = 'one\rtwo\nthree\rfour\n'
+      newText = 'one\rtwo and\nthree\rfour\n'
+      buffer.setText(oldText)
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+      buffer.undo()
+      expect(buffer.getText()).toBe oldText
+
     describe "with standard newlines", ->
       it "can change the entire contents of the buffer with no newline at the end", ->
         newText = "I know you are.\nBut what am I?"

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -762,14 +762,9 @@ class TextBuffer
     currentText = @getText()
     return if currentText is text
 
-    endsWithNewline = (str) ->
-      /[\r\n]+$/g.test(str)
-
     computeBufferColumn = (str) ->
-      newlineIndex = Math.max(str.lastIndexOf('\n'), str.lastIndexOf('\r'))
-      if endsWithNewline(str)
-        0
-      else if newlineIndex is -1
+      newlineIndex = str.lastIndexOf('\n')
+      if newlineIndex is -1
         str.length
       else
         str.length - newlineIndex - 1
@@ -783,8 +778,7 @@ class TextBuffer
       changeOptions = normalizeLineEndings: false
 
       for change in lineDiff
-        # Using change.count does not account for lone carriage-returns
-        lineCount = change.value.match(newlineRegex)?.length ? 0
+        lineCount = change.count
         currentPosition[0] = row
         currentPosition[1] = column
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/15225

I overlooked the `setTextViaDiff` method during the TextBuffer rewrite since Atom core no longer uses it for anything and its existing tests continued to pass. It had code that assumed that lone CR characters should be treated as line breaks, which Atom used to do, but no longer does.