### PR TITLE
Avoid spatial index corruption when Infinity is passed to DisplayLayer.populateSpatialIndexIfNeeded

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -2273,7 +2273,7 @@ describe('DisplayLayer', () => {
         const screenLinesById = new Map()
 
         for (let j = 0; j < 10; j++) {
-          const k = random(10)
+          const k = random(11)
 
           if (k < 2) {
             createRandomFold(random, displayLayer, foldIds)
@@ -2292,9 +2292,12 @@ describe('DisplayLayer', () => {
             performRedo(random, displayLayer)
           } else if (k < 8) {
             textDecorationLayer.emitInvalidateRangeEvent(getRandomBufferRange(random, buffer))
-          } else {
+          } else if (k < 10) {
             undoableChanges++
             performRandomChange(random, displayLayer)
+          } else {
+            const softWrapColumn = random(2) ? random.intBetween(5, 80) : null
+            displayLayer.reset({softWrapColumn})
           }
 
           if (!hasComputedAllScreenRows(displayLayer)) {

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -2193,6 +2193,22 @@ describe('DisplayLayer', () => {
     })
   })
 
+  describe('.populateSpatialIndexIfNeeded(endBufferRow, endScreenRow, deadline)', () => {
+    it('updates the spatial index correctly when the endBufferRow exceets the buffer row count', () => {
+      const buffer = new TextBuffer({
+        text: SAMPLE_TEXT
+      })
+
+      const displayLayer = buffer.addDisplayLayer()
+      displayLayer.foldBufferRange([[4, 29], [7, 4]])
+      const expectedText = displayLayer.getText()
+      displayLayer.clearSpatialIndex()
+
+      displayLayer.populateSpatialIndexIfNeeded(Infinity, Infinity)
+      expect(displayLayer.getText()).toBe(expectedText)
+    })
+  })
+
   describe('.bufferRowsForScreenRows(startRow, endRow)', () => {
     it('returns an array containing the buffer rows for the given screen row range', () => {
       const buffer = new TextBuffer({text: 'abcde\nfghij\nklmno\npqrst\nuvwxyz'})

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -1056,6 +1056,7 @@ class DisplayLayer {
   }
 
   populateSpatialIndexIfNeeded (endBufferRow, endScreenRow, deadline = NullDeadline) {
+    endBufferRow = Math.min(this.buffer.getLineCount(), endBufferRow)
     if (endBufferRow > this.indexedBufferRowCount && endScreenRow > this.screenLineLengths.length) {
       this.updateSpatialIndex(
         this.indexedBufferRowCount,

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -587,6 +587,7 @@ class DisplayLayer {
   }
 
   lineLengthForScreenRow (screenRow) {
+    this.populateSpatialIndexIfNeeded(this.buffer.getLineCount(), screenRow + 1)
     return this.screenLineLengths[screenRow]
   }
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/15190

On [this line](https://github.com/atom/atom/blob/2f2d62ca51d91c4b8730bce0a0d0c1b12991704c/src/text-editor-component.js#L2791) of the text editor rendering rewrite, we call `DisplayLayer.prototype.populateSpatialIndexIfNeeded` with `Infinity` as the `endBufferRow` argument, in an attempt to express that we only care about the `endScreenRow` value.

Unfortunately, doing this was causing a `NaN` to be produced as the result of an expression within `updateSpatialIndex`. This `NaN` was used as the the end row in the query to the folds marker layer, causing us to not to render any folds even though folds were actually present.

The fix is to use `Math.min` to translate `Infinity` to `buffer.getLineCount()`, thereby avoiding the `NaN` in subsequent arithmetic.

/cc @as-cii 