### PR TITLE
Use native text buffer to check if file is unmodified & to be deleted

### DIFF
--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -928,7 +928,6 @@ describe('TextBuffer IO', () => {
         })
 
         it('destroys the buffer', (done) => {
-          console.log('set closeDeletedFileTabs to true', closeDeletedFileTabs)
           buffer.onDidDestroy(() => done())
           expect(buffer.isDestroyed()).toBeFalsy()
           expect(buffer.isModified()).toBeFalsy()

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -891,12 +891,12 @@ describe('TextBuffer IO', () => {
   })
 
   describe('when the file is deleted', () => {
-    let filePath
+    let filePath, closeDeletedFileTabs
 
     beforeEach((done) => {
       filePath = path.join(temp.mkdirSync(), 'file-to-delete')
       fs.writeFileSync(filePath, 'delete me')
-      TextBuffer.load(filePath).then((result) => {
+      TextBuffer.load(filePath, {shouldDestroyOnFileDelete: () => closeDeletedFileTabs}).then((result) => {
         buffer = result
         filePath = buffer.getPath() // symlinks may have been converted
         done()
@@ -918,15 +918,37 @@ describe('TextBuffer IO', () => {
     })
 
     describe('when the file is not modified', () => {
-      beforeEach((done) => {
+      beforeEach(() => {
         expect(buffer.isModified()).toBeFalsy()
-        buffer.file.onDidDelete(() => done())
-        fs.removeSync(filePath)
       })
 
-      it('retains its path and reports the buffer as modified', () => {
-        expect(buffer.getPath()).toBe(filePath)
-        expect(buffer.isModified()).toBeTruthy()
+      describe('when shouldDestroyOnFileDelete returns true', () => {
+        beforeEach(() => {
+          closeDeletedFileTabs = true
+        })
+
+        it('destroys the buffer', (done) => {
+          console.log('set closeDeletedFileTabs to true', closeDeletedFileTabs)
+          buffer.onDidDestroy(() => done())
+          expect(buffer.isDestroyed()).toBeFalsy()
+          expect(buffer.isModified()).toBeFalsy()
+          fs.removeSync(filePath)
+        })
+      })
+
+      describe('when shouldDestroyOnFileDelete returns false', () => {
+        beforeEach(() => {
+          closeDeletedFileTabs = false
+        })
+
+        it('retains its path and reports the buffer as modified', (done) => {
+          fs.removeSync(filePath)
+          buffer.file.onDidDelete(() => {
+            expect(buffer.getPath()).toBe(filePath)
+            expect(buffer.isModified()).toBeTruthy()
+            done()
+          })
+        })
       })
     })
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1764,7 +1764,7 @@ class TextBuffer
 
     if @file.onDidDelete?
       @fileSubscriptions.add @file.onDidDelete =>
-        modified = @isModified()
+        modified = @buffer.isModified()
         @emitter.emit 'did-delete'
         if not modified and @shouldDestroyOnFileDelete()
           @destroy()


### PR DESCRIPTION
Addresses regression described in https://github.com/atom/atom/issues/14765

In the callback for the pathwatcher delete event we want to destroy the buffer if the underlying file has been deleted, unless the file has been modified. When checking for modification status, we need to call the [superstring](https://www.npmjs.com/package/superstring) native buffer's `isModified` method rather than the `isModified` method on this module's TextBuffer class which first checks if the file exists. This file existence check is unnecessary and unwanted since the file won't exist after a deletion.

/cc @maxbrunsfeld 
