### PR TITLE
Restore the ability to save files owned by root on Mac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,129 +2,195 @@
   "name": "text-buffer",
   "version": "13.0.11",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "https://registry.npmjs.org/@types/node/-/node-7.0.41.tgz",
-      "integrity": "sha1-TbzprktVHfHvQEeQRgDFgU1Y4c4=",
+      "version": "7.0.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.42.tgz",
+      "integrity": "sha512-cF/2SHIITu6Xen1DqBobqsx63Bdui37ZnID90G/vkuF1T7orBijcgyYcgkRpChCRwoRaf4LV/jXjrfVtFL/Y8Q==",
       "dev": true
     },
     "ajv": {
-      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "array-find-index": {
-      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "asn1": {
-      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atom-jasmine2-test-runner": {
-      "version": "https://registry.npmjs.org/atom-jasmine2-test-runner/-/atom-jasmine2-test-runner-0.7.2.tgz",
-      "integrity": "sha1-k1EdBhQdaceCQi8JQt23g1CQvZk=",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/atom-jasmine2-test-runner/-/atom-jasmine2-test-runner-0.7.2.tgz",
+      "integrity": "sha512-VrKjssgAfCHakqu8gcfy4oxRZkRf0w8DqHQb6TlzcQYAToWklmPeD6DaMyceKsNG7XxQYdWOfyImdN7R9qXP7g==",
       "dev": true,
+      "requires": {
+        "find-parent-dir": "0.3.0",
+        "glob": "7.1.2",
+        "grim": "2.0.1",
+        "jasmine": "2.6.0",
+        "jasmine-local-storage": "1.0.0",
+        "jasmine-pass": "1.0.3",
+        "jasmine-promises": "0.4.1",
+        "jasmine-should-fail": "1.0.3",
+        "jasmine-unspy": "1.0.0",
+        "jasmine2-atom-matchers": "1.0.0",
+        "jasmine2-focused": "1.0.2",
+        "jasmine2-json": "1.0.1",
+        "jasmine2-tagged": "1.0.0",
+        "jquery": "3.2.1",
+        "pathwatcher": "7.1.0",
+        "underscore-plus": "1.6.6"
+      },
       "dependencies": {
-        "grim": {
-          "version": "https://registry.npmjs.org/grim/-/grim-2.0.1.tgz",
-          "integrity": "sha1-Kyb4kmmfObX2lSveWI589AcLab4=",
-          "dev": true
-        },
         "jasmine": {
-          "version": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
           "integrity": "sha1-ayLnCIPo5YnUVjRhU7TSBt2+IX8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "exit": "0.1.2",
+            "glob": "7.1.2",
+            "jasmine-core": "2.6.4"
+          }
         },
         "jasmine-core": {
-          "version": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.4.tgz",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.4.tgz",
           "integrity": "sha1-3skmzQqfoof7bbXHVfpIfnTOysU=",
           "dev": true
         }
       }
     },
     "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
-      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "builtin-modules": {
-      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "camelcase": {
-      "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
     "camelcase-keys": {
-      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "cliui": {
-      "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
     },
     "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
-      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
@@ -133,6 +199,9 @@
       "resolved": "https://registry.npmjs.org/coffee-cache/-/coffee-cache-0.2.0.tgz",
       "integrity": "sha1-eMOipj1sxgj39gG1UEiogshxsY8=",
       "dev": true,
+      "requires": {
+        "mkpath": "0.1.0"
+      },
       "dependencies": {
         "mkpath": {
           "version": "0.1.0",
@@ -149,97 +218,155 @@
       "dev": true
     },
     "coffeelint": {
-      "version": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.0.tgz",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.0.tgz",
       "integrity": "sha1-g9jtHa/eOmd95E57ihi+YHdh5tg=",
       "dev": true,
+      "requires": {
+        "coffee-script": "1.11.1",
+        "glob": "7.1.2",
+        "ignore": "3.3.3",
+        "optimist": "0.6.1",
+        "resolve": "0.6.3",
+        "strip-json-comments": "1.0.4"
+      },
       "dependencies": {
         "coffee-script": {
-          "version": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
           "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
           "dev": true
         }
       }
     },
     "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
-          "dev": true
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-          "dev": true
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "currently-unhandled": {
-      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "dashdash": {
-      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
-      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "dedent": {
-      "version": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
       "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
       "dev": true
     },
     "deep-extend": {
-      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
     "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -247,6 +374,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegato/-/delegato-1.0.0.tgz",
       "integrity": "sha1-xzJK2/Mfo9ltH9YL82jF/MomlRA=",
+      "requires": {
+        "mixto": "1.0.0"
+      },
       "dependencies": {
         "mixto": {
           "version": "1.0.0",
@@ -261,23 +391,46 @@
       "integrity": "sha1-X4E/mUoMqhou95IAdZxLicojOoE="
     },
     "ecc-jsbn": {
-      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "electron": {
-      "version": "https://registry.npmjs.org/electron/-/electron-1.6.12.tgz",
-      "integrity": "sha1-hg3fDGWWgfYLgV9LmMB3/htvhnw=",
-      "dev": true
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.12.tgz",
+      "integrity": "sha512-JncFnznbIOr73sKOaIb80twVW0gmf13h3LECYQPHlZ9RHWve1/Yw6NPqTapprfMJn81ipVxQqLw45fFF3LnrFQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.42",
+        "electron-download": "3.3.0",
+        "extract-zip": "1.6.5"
+      }
     },
     "electron-download": {
-      "version": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
       "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "fs-extra": "0.30.0",
+        "home-path": "1.0.5",
+        "minimist": "1.2.0",
+        "nugget": "2.0.1",
+        "path-exists": "2.1.0",
+        "rc": "1.2.1",
+        "semver": "5.4.1",
+        "sumchecker": "1.3.1"
+      },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -287,43 +440,80 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
       "integrity": "sha1-phjZLWgrIy0xER3DYlpd9mF5lgY=",
+      "requires": {
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0",
+        "property-accessors": "1.1.3",
+        "underscore-plus": "1.6.6"
+      },
       "dependencies": {
         "es6-weak-map": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
           "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11",
+            "es6-iterator": "0.1.3",
+            "es6-symbol": "2.0.1"
+          },
           "dependencies": {
             "d": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-              "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+              "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+              "requires": {
+                "es5-ext": "0.10.11"
+              }
             },
             "es5-ext": {
               "version": "0.10.11",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
               "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
+              "requires": {
+                "es6-iterator": "2.0.0",
+                "es6-symbol": "3.0.2"
+              },
               "dependencies": {
                 "es6-iterator": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                  "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w="
+                  "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.11",
+                    "es6-symbol": "3.0.2"
+                  }
                 },
                 "es6-symbol": {
                   "version": "3.0.2",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-                  "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk="
+                  "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.11"
+                  }
                 }
               }
             },
             "es6-iterator": {
               "version": "0.1.3",
               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-              "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4="
+              "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11",
+                "es6-symbol": "2.0.1"
+              }
             },
             "es6-symbol": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-              "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+              "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11"
+              }
             }
           }
         },
@@ -335,13 +525,27 @@
         "property-accessors": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
-          "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU="
+          "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU=",
+          "requires": {
+            "es6-weak-map": "0.1.4",
+            "mixto": "1.0.0"
+          }
         }
       }
     },
     "error-ex": {
-      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
       "dev": true
     },
     "eslint": {
@@ -349,12 +553,54 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.2.0.tgz",
       "integrity": "sha1-bI10OpFUZZW6GG7e0JZoL0dZjeg=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.5.1",
+        "debug": "2.2.0",
+        "doctrine": "1.2.2",
+        "es6-map": "0.1.3",
+        "escope": "3.6.0",
+        "espree": "3.1.4",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.2.4",
+        "glob": "6.0.4",
+        "globals": "8.18.0",
+        "ignore": "2.2.19",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.13.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.6.1",
+        "json-stable-stringify": "1.0.1",
+        "lodash": "4.13.1",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.1",
+        "path-is-absolute": "1.0.0",
+        "path-is-inside": "1.0.1",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.2",
+        "resolve": "1.1.7",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "table": "3.7.8",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
@@ -373,6 +619,9 @@
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -387,6 +636,9 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -409,6 +661,11 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
           "dev": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
+          },
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
@@ -421,6 +678,14 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -467,6 +732,9 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          },
           "dependencies": {
             "ms": {
               "version": "0.7.1",
@@ -481,6 +749,10 @@
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.2.tgz",
           "integrity": "sha1-nphnIQFJVIuV7FFGna5MqtMSMI4=",
           "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "1.0.0"
+          },
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
@@ -501,42 +773,77 @@
           "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
           "integrity": "sha1-/ljGZUxqzVTkOXzbcjedWbatWJQ=",
           "dev": true,
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.11",
+            "es6-iterator": "2.0.0",
+            "es6-set": "0.1.4",
+            "es6-symbol": "3.0.2",
+            "event-emitter": "0.3.4"
+          },
           "dependencies": {
             "d": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
               "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "es5-ext": "0.10.11"
+              }
             },
             "es5-ext": {
               "version": "0.10.11",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
               "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "es6-iterator": "2.0.0",
+                "es6-symbol": "3.0.2"
+              }
             },
             "es6-iterator": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
               "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11",
+                "es6-symbol": "3.0.2"
+              }
             },
             "es6-set": {
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
               "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11",
+                "es6-iterator": "2.0.0",
+                "es6-symbol": "3.0.2",
+                "event-emitter": "0.3.4"
+              }
             },
             "es6-symbol": {
               "version": "3.0.2",
               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
               "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11"
+              }
             },
             "event-emitter": {
               "version": "0.3.4",
               "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
               "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11"
+              }
             }
           }
         },
@@ -545,36 +852,64 @@
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
           "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
           "dev": true,
+          "requires": {
+            "es6-map": "0.1.3",
+            "es6-weak-map": "2.0.1",
+            "esrecurse": "4.1.0",
+            "estraverse": "4.2.0"
+          },
           "dependencies": {
             "es6-weak-map": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
               "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
               "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.11",
+                "es6-iterator": "2.0.0",
+                "es6-symbol": "3.0.2"
+              },
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "0.10.11"
+                  }
                 },
                 "es5-ext": {
                   "version": "0.10.11",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
                   "integrity": "sha1-gYTD5wWoIJSMLb4EOEk3mx29DEU=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "2.0.0",
+                    "es6-symbol": "3.0.2"
+                  }
                 },
                 "es6-iterator": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                   "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.11",
+                    "es6-symbol": "3.0.2"
+                  }
                 },
                 "es6-symbol": {
                   "version": "3.0.2",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
                   "integrity": "sha1-HpKIeMb15jVBYltLtN9K8H0VQhk=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.11"
+                  }
                 }
               }
             },
@@ -583,6 +918,10 @@
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
               "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
               "dev": true,
+              "requires": {
+                "estraverse": "4.1.1",
+                "object-assign": "4.1.0"
+              },
               "dependencies": {
                 "estraverse": {
                   "version": "4.1.1",
@@ -605,6 +944,10 @@
           "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.4.tgz",
           "integrity": "sha1-BybXrIOvl6fISY2ps2OjYJ0qaKE=",
           "dev": true,
+          "requires": {
+            "acorn": "3.1.0",
+            "acorn-jsx": "3.0.1"
+          },
           "dependencies": {
             "acorn": {
               "version": "3.1.0",
@@ -616,7 +959,10 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
               "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "acorn": "3.1.0"
+              }
             }
           }
         },
@@ -643,30 +989,60 @@
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
           "integrity": "sha1-mlhgcsaTZafvfscqfCuQRt4JHpw=",
           "dev": true,
+          "requires": {
+            "flat-cache": "1.0.10",
+            "object-assign": "4.1.0"
+          },
           "dependencies": {
             "flat-cache": {
               "version": "1.0.10",
               "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
               "integrity": "sha1-c9bfSihQIWCgXgWVRKau6uiwBHo=",
               "dev": true,
+              "requires": {
+                "del": "2.2.0",
+                "graceful-fs": "4.1.4",
+                "read-json-sync": "1.1.1",
+                "write": "0.2.1"
+              },
               "dependencies": {
                 "del": {
                   "version": "2.2.0",
                   "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
                   "integrity": "sha1-mlDwS/NzJeKDtPROmFM2wlJFa9U=",
                   "dev": true,
+                  "requires": {
+                    "globby": "4.1.0",
+                    "is-path-cwd": "1.0.0",
+                    "is-path-in-cwd": "1.0.0",
+                    "object-assign": "4.1.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "rimraf": "2.2.8"
+                  },
                   "dependencies": {
                     "globby": {
                       "version": "4.1.0",
                       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
                       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
                       "dev": true,
+                      "requires": {
+                        "array-union": "1.0.1",
+                        "arrify": "1.0.1",
+                        "glob": "6.0.4",
+                        "object-assign": "4.1.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
                       "dependencies": {
                         "array-union": {
                           "version": "1.0.1",
                           "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
                           "integrity": "sha1-TUEPyDlcskdjcSS63p4/VH1dVfI=",
                           "dev": true,
+                          "requires": {
+                            "array-uniq": "1.0.2"
+                          },
                           "dependencies": {
                             "array-uniq": {
                               "version": "1.0.2",
@@ -695,12 +1071,18 @@
                       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
                       "dev": true,
+                      "requires": {
+                        "is-path-inside": "1.0.0"
+                      },
                       "dependencies": {
                         "is-path-inside": {
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
                           "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                          "dev": true
+                          "dev": true,
+                          "requires": {
+                            "path-is-inside": "1.0.1"
+                          }
                         }
                       }
                     },
@@ -715,6 +1097,9 @@
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
@@ -736,13 +1121,19 @@
                   "version": "1.1.1",
                   "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
                   "integrity": "sha1-Q8ZproZKrjCN+7snIaZ+KV7I//Y=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.4"
+                  }
                 },
                 "write": {
                   "version": "0.2.1",
                   "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
                   "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                  "dev": true
+                  "dev": true,
+                  "requires": {
+                    "mkdirp": "0.5.1"
+                  }
                 }
               }
             },
@@ -759,12 +1150,23 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
+          "requires": {
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          },
           "dependencies": {
             "inflight": {
               "version": "1.0.5",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
+              "requires": {
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -785,12 +1187,19 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
               "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.4"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.4",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                   "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                   "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.1",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.1",
@@ -813,6 +1222,9 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
@@ -841,6 +1253,21 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.0.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.1.0",
+            "figures": "1.7.0",
+            "lodash": "4.13.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.1",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          },
           "dependencies": {
             "ansi-escapes": {
               "version": "1.4.0",
@@ -859,12 +1286,19 @@
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
               "dev": true,
+              "requires": {
+                "restore-cursor": "1.0.1"
+              },
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
                   "dev": true,
+                  "requires": {
+                    "exit-hook": "1.1.1",
+                    "onetime": "1.1.0"
+                  },
                   "dependencies": {
                     "exit-hook": {
                       "version": "1.1.1",
@@ -893,6 +1327,10 @@
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
               "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
               "dev": true,
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.0"
+              },
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.5",
@@ -913,12 +1351,20 @@
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
               "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
               "dev": true,
+              "requires": {
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "mute-stream": "0.0.5"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -933,6 +1379,9 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -955,12 +1404,18 @@
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
               "dev": true,
+              "requires": {
+                "once": "1.3.3"
+              },
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                   "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
@@ -983,12 +1438,20 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
+              "requires": {
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -1003,6 +1466,9 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -1018,7 +1484,10 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              }
             },
             "through": {
               "version": "2.3.8",
@@ -1033,6 +1502,12 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
           "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
           "dev": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "2.0.0",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "generate-function": {
               "version": "2.0.0",
@@ -1045,6 +1520,9 @@
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
               "dev": true,
+              "requires": {
+                "is-property": "1.0.2"
+              },
               "dependencies": {
                 "is-property": {
                   "version": "1.0.2",
@@ -1073,6 +1551,9 @@
           "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
           "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
           "dev": true,
+          "requires": {
+            "tryit": "1.0.2"
+          },
           "dependencies": {
             "tryit": {
               "version": "1.0.2",
@@ -1087,12 +1568,19 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
           "dev": true,
+          "requires": {
+            "argparse": "1.0.7",
+            "esprima": "2.7.2"
+          },
           "dependencies": {
             "argparse": {
               "version": "1.0.7",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
               "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
@@ -1115,6 +1603,9 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          },
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
@@ -1135,6 +1626,9 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -1149,6 +1643,14 @@
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
           "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
           "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.1.3",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          },
           "dependencies": {
             "deep-is": {
               "version": "0.1.3",
@@ -1166,7 +1668,11 @@
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
               "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
             },
             "prelude-ls": {
               "version": "1.1.2",
@@ -1178,7 +1684,10 @@
               "version": "0.3.2",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
               "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
             },
             "wordwrap": {
               "version": "1.0.0",
@@ -1217,12 +1726,19 @@
           "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
           "integrity": "sha1-Z9rTtzMInncDASRnikWVifr2p+w=",
           "dev": true,
+          "requires": {
+            "caller-path": "0.1.0",
+            "resolve-from": "1.0.1"
+          },
           "dependencies": {
             "caller-path": {
               "version": "0.1.0",
               "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
               "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
               "dev": true,
+              "requires": {
+                "callsites": "0.2.0"
+              },
               "dependencies": {
                 "callsites": {
                   "version": "0.2.0",
@@ -1263,6 +1779,16 @@
           "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
           "integrity": "sha1-tCRDPvWWhRkisv13IkppoZUWGOs=",
           "dev": true,
+          "requires": {
+            "bluebird": "3.4.0",
+            "chalk": "1.1.3",
+            "lodash": "4.13.1",
+            "slice-ansi": "0.0.4",
+            "string-width": "1.0.1",
+            "strip-ansi": "3.0.1",
+            "tv4": "1.2.7",
+            "xregexp": "3.1.1"
+          },
           "dependencies": {
             "bluebird": {
               "version": "3.4.0",
@@ -1281,12 +1807,20 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
+              "requires": {
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -1301,6 +1835,9 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
@@ -1317,6 +1854,9 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -1351,6 +1891,9 @@
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
+          "requires": {
+            "os-homedir": "1.0.1"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
@@ -1381,130 +1924,230 @@
       "dev": true
     },
     "event-kit": {
-      "version": "https://registry.npmjs.org/event-kit/-/event-kit-2.3.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.3.0.tgz",
       "integrity": "sha1-RZugZG1Lfbyl2b8rPE4tAQPoXhU="
     },
     "exit": {
-      "version": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extract-zip": {
-      "version": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
       "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
       "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "debug": "2.2.0",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         }
       }
     },
     "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fd-slicer": {
-      "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
     },
     "find-parent-dir": {
-      "version": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
       "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
     },
     "find-up": {
-      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.16"
+      }
     },
     "fs-extra": {
-      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
+      }
     },
     "fs-plus": {
-      "version": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
       "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+      "requires": {
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "underscore-plus": "1.6.6"
+      },
       "dependencies": {
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "requires": {
+            "glob": "7.1.2"
+          }
         }
       }
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "get-caller-file": {
-      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
     "get-stdin": {
-      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "getpass": {
-      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "grim": {
-      "version": "https://registry.npmjs.org/grim/-/grim-2.0.1.tgz",
-      "integrity": "sha1-Kyb4kmmfObX2lSveWI589AcLab4="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.1.tgz",
+      "integrity": "sha1-Kyb4kmmfObX2lSveWI589AcLab4=",
+      "requires": {
+        "event-kit": "2.3.0"
+      }
     },
     "grunt": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.3",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
       "dependencies": {
         "async": {
           "version": "0.1.22",
@@ -1547,12 +2190,20 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
           "dev": true,
+          "requires": {
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
+          },
           "dependencies": {
             "glob": {
               "version": "3.2.11",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
               "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "minimatch": "0.3.0"
+              },
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
@@ -1565,6 +2216,10 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
                   "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -1601,6 +2256,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          },
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
@@ -1621,12 +2281,24 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
           "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
           "dev": true,
+          "requires": {
+            "colors": "0.6.2",
+            "grunt-legacy-log-utils": "0.1.1",
+            "hooker": "0.2.3",
+            "lodash": "2.4.2",
+            "underscore.string": "2.3.3"
+          },
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
               "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "colors": "0.6.2",
+                "lodash": "2.4.2",
+                "underscore.string": "2.3.3"
+              }
             },
             "lodash": {
               "version": "2.4.2",
@@ -1646,7 +2318,16 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
           "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "async": "0.1.22",
+            "exit": "0.1.2",
+            "getobject": "0.1.0",
+            "hooker": "0.2.3",
+            "lodash": "0.9.2",
+            "underscore.string": "2.2.1",
+            "which": "1.0.9"
+          }
         },
         "hooker": {
           "version": "0.2.3",
@@ -1665,12 +2346,20 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          },
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
               "dev": true,
+              "requires": {
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
+              },
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
@@ -1705,6 +2394,10 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          },
           "dependencies": {
             "lru-cache": {
               "version": "2.7.3",
@@ -1725,6 +2418,9 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
+          "requires": {
+            "abbrev": "1.0.7"
+          },
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
@@ -1753,12 +2449,26 @@
       "resolved": "https://registry.npmjs.org/grunt-atomdoc/-/grunt-atomdoc-1.0.1.tgz",
       "integrity": "sha1-1fDuKVwBc/9N6p1AvCI+drjM8cc=",
       "dev": true,
+      "requires": {
+        "donna": "1.0.13",
+        "tello": "1.0.6"
+      },
       "dependencies": {
         "donna": {
           "version": "1.0.13",
           "resolved": "https://registry.npmjs.org/donna/-/donna-1.0.13.tgz",
           "integrity": "sha1-pXbE8ssCSkOvSxO031JsMT65Tng=",
           "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "builtins": "0.0.4",
+            "coffee-script": "1.10.0",
+            "optimist": "0.6.1",
+            "source-map": "0.1.29",
+            "underscore": "1.8.3",
+            "underscore.string": "3.3.4",
+            "walkdir": "0.0.11"
+          },
           "dependencies": {
             "async": {
               "version": "1.5.2",
@@ -1777,6 +2487,10 @@
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "dev": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
@@ -1797,6 +2511,9 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.29.tgz",
               "integrity": "sha1-OdVxoJiPt6VIpnbE3nLbeJFNFzw=",
               "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
@@ -1817,6 +2534,10 @@
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
               "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
               "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
@@ -1845,12 +2566,21 @@
           "resolved": "https://registry.npmjs.org/tello/-/tello-1.0.6.tgz",
           "integrity": "sha1-+9sLPY0cIirftAW2pCQ1XmBR17Y=",
           "dev": true,
+          "requires": {
+            "atomdoc": "1.0.4",
+            "optimist": "0.6.1",
+            "underscore": "1.6.0"
+          },
           "dependencies": {
             "atomdoc": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/atomdoc/-/atomdoc-1.0.4.tgz",
               "integrity": "sha1-imT6cApGfOFjqh7SgV3kUhvvdIs=",
               "dev": true,
+              "requires": {
+                "marked": "0.3.5",
+                "underscore": "1.6.0"
+              },
               "dependencies": {
                 "marked": {
                   "version": "0.3.5",
@@ -1865,6 +2595,10 @@
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "dev": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
@@ -1895,18 +2629,31 @@
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
+      "requires": {
+        "findup-sync": "0.1.3",
+        "nopt": "1.0.10",
+        "resolve": "0.3.1"
+      },
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
           "dev": true,
+          "requires": {
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
+          },
           "dependencies": {
             "glob": {
               "version": "3.2.11",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
               "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "minimatch": "0.3.0"
+              },
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
@@ -1919,6 +2666,10 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
                   "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -1949,6 +2700,9 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
+          "requires": {
+            "abbrev": "1.0.7"
+          },
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
@@ -1971,12 +2725,24 @@
       "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.0.tgz",
       "integrity": "sha1-3lYGCpNN+OzuZAdLYcYwSQDXEVg=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "npm-run-path": "1.0.0",
+        "object-assign": "4.1.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
@@ -1995,6 +2761,9 @@
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -2009,6 +2778,9 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
@@ -2031,6 +2803,9 @@
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
           "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
           "dev": true,
+          "requires": {
+            "path-key": "1.0.0"
+          },
           "dependencies": {
             "path-key": {
               "version": "1.0.0",
@@ -2049,109 +2824,162 @@
       }
     },
     "har-schema": {
-      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
       "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true
     },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "home-path": {
-      "version": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
       "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
       "dev": true
     },
     "hosted-git-info": {
-      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
     },
     "ignore": {
-      "version": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
       "dev": true
     },
     "indent-string": {
-      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
     "invert-kv": {
-      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "is-arrayish": {
-      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-builtin-module": {
-      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-finite": {
-      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
-      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-typedarray": {
-      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
-      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -2160,6 +2988,11 @@
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
       "integrity": "sha1-kBbdpFMhPSesbUPcTqlzFaGJCF4=",
       "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "3.2.11",
+        "jasmine-core": "2.4.1"
+      },
       "dependencies": {
         "exit": {
           "version": "0.1.2",
@@ -2172,6 +3005,10 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "minimatch": "0.3.0"
+          },
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
@@ -2184,6 +3021,10 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              },
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
@@ -2210,67 +3051,82 @@
       "dev": true
     },
     "jasmine-local-storage": {
-      "version": "https://registry.npmjs.org/jasmine-local-storage/-/jasmine-local-storage-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-local-storage/-/jasmine-local-storage-1.0.0.tgz",
       "integrity": "sha1-J8W68YenjG6oLLjkMRg6cV1Dr+g=",
       "dev": true,
       "optional": true
     },
     "jasmine-pass": {
-      "version": "https://registry.npmjs.org/jasmine-pass/-/jasmine-pass-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/jasmine-pass/-/jasmine-pass-1.0.3.tgz",
       "integrity": "sha1-waBEnhpv9JEcpwjxxKGg18gsID8=",
       "dev": true,
       "optional": true
     },
     "jasmine-promises": {
-      "version": "https://registry.npmjs.org/jasmine-promises/-/jasmine-promises-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/jasmine-promises/-/jasmine-promises-0.4.1.tgz",
       "integrity": "sha1-OGtj4scU0z2bG3ra5Qd3M2bb8Ks=",
       "dev": true,
       "optional": true
     },
     "jasmine-should-fail": {
-      "version": "https://registry.npmjs.org/jasmine-should-fail/-/jasmine-should-fail-1.0.3.tgz",
-      "integrity": "sha1-Ea4zr9gicFbiUEwfjqKaPpgSm68=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/jasmine-should-fail/-/jasmine-should-fail-1.0.3.tgz",
+      "integrity": "sha512-gpyfIrq21nZ1X4gGTbaKue+m8WGwwPNjxS2L609fWvYfjmOYT7hO63smWbDQYwrFqaP1ud8AGUj2WOn0n+7JLQ==",
       "dev": true,
       "optional": true
     },
     "jasmine-unspy": {
-      "version": "https://registry.npmjs.org/jasmine-unspy/-/jasmine-unspy-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-unspy/-/jasmine-unspy-1.0.0.tgz",
       "integrity": "sha1-zn4dL4JDlPXbvVIqPy0M2Bfm8zA=",
       "dev": true,
       "optional": true
     },
     "jasmine2-atom-matchers": {
-      "version": "https://registry.npmjs.org/jasmine2-atom-matchers/-/jasmine2-atom-matchers-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine2-atom-matchers/-/jasmine2-atom-matchers-1.0.0.tgz",
       "integrity": "sha1-v5EgaWyJLYP22UJ9Bd3Nkir32n4=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jquery": "3.2.1",
+        "underscore-plus": "1.6.6"
+      }
     },
     "jasmine2-focused": {
-      "version": "https://registry.npmjs.org/jasmine2-focused/-/jasmine2-focused-1.0.2.tgz",
-      "integrity": "sha1-f3cmR9pYWVbJBTndGyQIiCgh0jk=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jasmine2-focused/-/jasmine2-focused-1.0.2.tgz",
+      "integrity": "sha512-cp4qqauW0dYRAAZNEIIs6Ftv0Qii9NK1pHp7l72PPj8OIgu8YCZMweDP6xQXZbLPzkrrR20xPP8azH9KGAFmtA==",
       "dev": true,
       "optional": true
     },
     "jasmine2-json": {
-      "version": "https://registry.npmjs.org/jasmine2-json/-/jasmine2-json-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jasmine2-json/-/jasmine2-json-1.0.1.tgz",
       "integrity": "sha1-LruY3M1w9ypT7vyBbk+xgqo+o/Q=",
       "dev": true,
       "optional": true
     },
     "jasmine2-tagged": {
-      "version": "https://registry.npmjs.org/jasmine2-tagged/-/jasmine2-tagged-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine2-tagged/-/jasmine2-tagged-1.0.0.tgz",
       "integrity": "sha1-7SODt4c+0Z1iGYo08g3qtgcwXVI=",
       "dev": true,
       "optional": true
     },
     "jquery": {
-      "version": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
       "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
       "dev": true,
       "optional": true
     },
     "jsbn": {
-      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
@@ -2280,12 +3136,20 @@
       "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
       "integrity": "sha1-bbw64tJeB1p/1xvNmHRFhmb7aBs=",
       "dev": true,
+      "requires": {
+        "cli-color": "0.1.7",
+        "difflib": "0.2.4",
+        "dreamopt": "0.6.0"
+      },
       "dependencies": {
         "cli-color": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
           "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
           "dev": true,
+          "requires": {
+            "es5-ext": "0.8.2"
+          },
           "dependencies": {
             "es5-ext": {
               "version": "0.8.2",
@@ -2300,6 +3164,9 @@
           "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
           "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
           "dev": true,
+          "requires": {
+            "heap": "0.2.6"
+          },
           "dependencies": {
             "heap": {
               "version": "0.2.6",
@@ -2314,6 +3181,9 @@
           "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
           "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
           "dev": true,
+          "requires": {
+            "wordwrap": "1.0.0"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "1.0.0",
@@ -2326,242 +3196,392 @@
       }
     },
     "json-schema": {
-      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonfile": {
-      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "klaw": {
-      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "lcid": {
-      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "load-json-file": {
-      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "loud-rejection": {
-      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "map-obj": {
-      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "meow": {
-      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
       "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
       "dev": true
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.29.0"
+      }
     },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "nan": {
-      "version": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
     },
     "normalize-package-data": {
-      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "nugget": {
-      "version": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
       "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "minimist": "1.2.0",
+        "pretty-bytes": "1.0.4",
+        "progress-stream": "1.2.0",
+        "request": "2.81.0",
+        "single-line-log": "1.1.2",
+        "throttleit": "0.0.2"
+      },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "number-is-nan": {
-      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "dev": true
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "optimist": {
-      "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      }
     },
     "os-locale": {
-      "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "parse-json": {
-      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "path-exists": {
-      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-type": {
-      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pathwatcher": {
-      "version": "https://registry.npmjs.org/pathwatcher/-/pathwatcher-7.1.0.tgz",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pathwatcher/-/pathwatcher-7.1.0.tgz",
       "integrity": "sha1-M72hshCqmKhmdr6ZJ0WjDZZRF3A=",
+      "requires": {
+        "async": "0.2.10",
+        "emissary": "1.3.3",
+        "event-kit": "2.3.0",
+        "fs-plus": "3.0.1",
+        "grim": "2.0.1",
+        "iconv-lite": "0.4.18",
+        "nan": "2.6.2",
+        "runas": "3.1.1",
+        "underscore-plus": "1.6.6"
+      },
       "dependencies": {
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "grim": {
-          "version": "https://registry.npmjs.org/grim/-/grim-2.0.1.tgz",
-          "integrity": "sha1-Kyb4kmmfObX2lSveWI589AcLab4="
         }
       }
     },
     "pend": {
-      "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
-      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
     "pify": {
-      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
-      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
-      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pretty-bytes": {
-      "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
     },
     "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress-stream": {
-      "version": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
       "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "speedometer": "0.1.4",
+        "through2": "0.2.3"
+      }
     },
     "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
       "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
       "dev": true
     },
@@ -2572,69 +3592,134 @@
       "dev": true
     },
     "rc": {
-      "version": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
       }
     },
     "read-pkg": {
-      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
-      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "redent": {
-      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
     },
     "regression": {
-      "version": "https://registry.npmjs.org/regression/-/regression-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regression/-/regression-1.4.0.tgz",
       "integrity": "sha1-00aPn7raHHAWHfMfbGQwFnesWnA=",
       "dev": true
     },
     "repeating": {
-      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.16",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      }
     },
     "require-directory": {
-      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
-      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
       "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
       "dev": true
     },
@@ -2648,6 +3733,9 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/runas/-/runas-3.1.1.tgz",
       "integrity": "sha1-Ut1TjbDkF0U5lTWjRwkbpFzA6rA=",
+      "requires": {
+        "nan": "2.3.3"
+      },
       "dependencies": {
         "nan": {
           "version": "2.3.3",
@@ -2657,19 +3745,26 @@
       }
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "serializable": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/serializable/-/serializable-1.0.3.tgz",
       "integrity": "sha1-ClqLa3d3yyRUTfEab4iabSs+EYk=",
+      "requires": {
+        "get-parameter-names": "0.2.0",
+        "mixto": "1.0.0",
+        "underscore-plus": "1.6.6"
+      },
       "dependencies": {
         "get-parameter-names": {
           "version": "0.2.0",
@@ -2684,113 +3779,177 @@
       }
     },
     "set-blocking": {
-      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "single-line-log": {
-      "version": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
       "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
     },
     "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "spawn-as-admin": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/spawn-as-admin/-/spawn-as-admin-0.1.2.tgz",
+      "integrity": "sha512-yAhV9IGbJ8oTZWIJUFFnV+wmubhwSnVX1+44voxR63QIBGeOW09B5epv/KnsS8o59KMQXBp7TEy8wF6SlgWaLg==",
+      "requires": {
+        "nan": "2.6.2"
+      }
     },
     "spdx-correct": {
-      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
-      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
-      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
     "speedometer": {
-      "version": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
       "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
       "dev": true
     },
     "sshpk": {
-      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-width": {
-      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-indent": {
-      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "sumchecker": {
-      "version": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
       "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
       "dev": true,
-      "dependencies": {
-        "es6-promise": {
-          "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-          "integrity": "sha1-iBHpCRXZoNujYnTwskLb2nj5ySo=",
-          "dev": true
-        }
+      "requires": {
+        "debug": "2.6.8",
+        "es6-promise": "4.1.1"
       }
     },
     "superstring": {
-      "version": "https://registry.npmjs.org/superstring/-/superstring-2.0.10.tgz",
-      "integrity": "sha1-0Dq0NlLHgvQlxKBijDC14Rl5GFg="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.0.10.tgz",
+      "integrity": "sha1-0Dq0NlLHgvQlxKBijDC14Rl5GFg=",
+      "requires": {
+        "nan": "2.6.2"
+      }
     },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.1",
+        "rimraf": "2.2.8"
+      },
       "dependencies": {
         "os-tmpdir": {
           "version": "1.0.1",
@@ -2801,38 +3960,55 @@
       }
     },
     "throttleit": {
-      "version": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
       "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
       "dev": true
     },
     "through2": {
-      "version": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      }
     },
     "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim-newlines": {
-      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
-      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "typedarray": {
-      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -2840,6 +4016,9 @@
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
       "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "requires": {
+        "underscore": "1.6.0"
+      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
@@ -2849,89 +4028,142 @@
       }
     },
     "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "which-module": {
-      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-keys": "0.4.0"
+      }
     },
     "y18n": {
-      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yargs": {
-      "version": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
+      },
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
       }
     },
     "yauzl": {
-      "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mkdirp": "^0.5.1",
     "pathwatcher": "7.1.0",
     "serializable": "^1.0.3",
+    "spawn-as-admin": "^0.1.2",
     "superstring": "^2.0.10",
     "underscore-plus": "^1.0.0"
   }

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1564,6 +1564,8 @@ class TextBuffer
     directoryPromise
       .then => @buffer.save(destination, @getEncoding())
       .catch (e) =>
+        if process.platform is 'darwin' and e.code is 'EACCES' and destination is filePath
+          return @_saveWithEscalatedPrivileges(filePath)
         @outstandingSaveCount--
         throw e
       .then =>
@@ -1602,6 +1604,24 @@ class TextBuffer
   ###
   Section: Private Utility Methods
   ###
+
+  _saveWithEscalatedPrivileges: (filePath) ->
+    @_spawnAsAdmin ?= require('spawn-as-admin')
+    adminProcess = @_spawnAsAdmin('dd', ['of=' + filePath])
+
+    @buffer.save(adminProcess.stdin, @getEncoding())
+      .then ->
+        adminProcess.stdin.end()
+      .catch (error) ->
+        adminProcess.kill()
+        throw error
+
+    new Promise (resolve, reject) ->
+      adminProcess.on 'exit', (code) ->
+        if code is 0
+          resolve()
+        else
+          reject(new Error('Failed to write to ' + filePath))
 
   loadSync: (options) ->
     unless options?.internal


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15267

The previous code for saving files owned by root relied on a synchronous native API: [`runas`](http://github.com/atom/node-runas). This PR adds a dependency on a new native module, [`spawn-as-admin`](https://github.com/atom/spawn-as-admin), which works very similarly to node's built-in `child_process.spawn` API, allowing us to save the file asynchronously.