### PR TITLE
Fix privilege escalation issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,7 @@ test_script:
   - npm test
 
 build: off
+
+branches:
+  only:
+    - master

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -273,6 +278,14 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -366,7 +379,6 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -572,6 +584,11 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
       "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
       "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "2.2.0",
@@ -2051,6 +2068,15 @@
         "mime-types": "2.1.16"
       }
     },
+    "fs-admin": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.1.1.tgz",
+      "integrity": "sha512-023EbQXyYKs4aMksk875cmlJdk8Y0yi4B81mXo94ctFwwLOj3SpFpB/kGHh22VJwXsGVMUCvkefvTSwKoZz2EA==",
+      "requires": {
+        "mocha": "3.5.0",
+        "nan": "2.6.2"
+      }
+    },
     "fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -2138,6 +2164,11 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
     "grim": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.1.tgz",
@@ -2145,6 +2176,11 @@
       "requires": {
         "event-kit": "2.3.0"
       }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
     },
     "grunt": {
       "version": "0.4.5",
@@ -2864,6 +2900,11 @@
         "har-schema": "1.0.5"
       }
     },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+    },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -3241,6 +3282,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -3305,6 +3351,65 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
+      }
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "loud-rejection": {
@@ -3385,11 +3490,48 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.6.2",
@@ -3836,14 +3978,6 @@
         "hoek": "2.16.3"
       }
     },
-    "spawn-as-admin": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/spawn-as-admin/-/spawn-as-admin-0.1.2.tgz",
-      "integrity": "sha512-yAhV9IGbJ8oTZWIJUFFnV+wmubhwSnVX1+44voxR63QIBGeOW09B5epv/KnsS8o59KMQXBp7TEy8wF6SlgWaLg==",
-      "requires": {
-        "nan": "2.6.2"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -3967,6 +4101,14 @@
       "integrity": "sha1-0Dq0NlLHgvQlxKBijDC14Rl5GFg=",
       "requires": {
         "nan": "2.6.2"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "requires": {
+        "has-flag": "1.0.0"
       }
     },
     "temp": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.1",
     "pathwatcher": "8.0.0",
     "serializable": "^1.0.3",
-    "superstring": "^2.0.10",
+    "superstring": "^2.0.11",
     "underscore-plus": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "diff": "^2.2.1",
     "emissary": "^1.0.0",
     "event-kit": "^2.1.0",
+    "fs-admin": "^0.1.1",
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
     "mkdirp": "^0.5.1",
     "pathwatcher": "8.0.0",
     "serializable": "^1.0.3",
-    "spawn-as-admin": "^0.1.3",
     "superstring": "^2.0.10",
     "underscore-plus": "^1.0.0"
   }

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -1,6 +1,5 @@
 const fs = require('fs-plus')
 const path = require('path')
-const {spawn} = require('child_process')
 const {Writable, Transform} = require('stream')
 const temp = require('temp')
 const {Disposable} = require('event-kit')
@@ -8,6 +7,7 @@ const Point = require('../src/point')
 const Range = require('../src/range')
 const TextBuffer = require('../src/text-buffer')
 const {TextBuffer: NativeTextBuffer} = require('superstring')
+const fsAdmin = require('fs-admin')
 
 process.on('unhandledRejection', console.error)
 
@@ -314,26 +314,22 @@ describe('TextBuffer IO', () => {
       })
 
       it('requests escalated privileges to save the file', (done) => {
-        buffer._spawnAsAdmin = spawn
-        spyOn(buffer, '_spawnAsAdmin').and.callThrough()
+        spyOn(fsAdmin, 'createWriteStream').and.callFake(() => fs.createWriteStream(filePath))
 
         buffer.setText('Buffer contents\n'.repeat(100))
 
         buffer.save().then(() => {
           expect(fs.readFileSync(filePath, 'utf8')).toEqual(buffer.getText())
-          expect(buffer._spawnAsAdmin).toHaveBeenCalled()
+          expect(fsAdmin.createWriteStream).toHaveBeenCalled()
           done()
         })
       })
 
       it('rejects if writing to the file fails', (done) => {
-        buffer._spawnAsAdmin = () => spawn('bash', ['-c', 'exit 1'])
+        spyOn(fsAdmin, 'createWriteStream').and.callFake(() => fs.createWriteStream('/etc/does/not/exist'))
 
         buffer.setText('Buffer contents\n'.repeat(100))
-        buffer.save().catch((error) => {
-          expect(error.message).toBe('Failed to write to ' + filePath)
-          done()
-        })
+        buffer.save().catch(done)
       })
     })
   })

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1563,12 +1563,15 @@ class TextBuffer
 
     directoryPromise
       .then => @buffer.save(destination, @getEncoding())
-      .catch (e) =>
-        if process.platform is 'darwin' and e.code is 'EACCES' and destination is filePath
+      .catch (error) =>
+        if process.platform is 'darwin' and error.code is 'EACCES' and destination is filePath
           fsAdmin = require('fs-admin')
-          return @buffer.save(fsAdmin.createWriteStream(filePath), @getEncoding())
+          @buffer.save(fsAdmin.createWriteStream(filePath), @getEncoding())
+        else
+          throw error
+      .catch (error) =>
         @outstandingSaveCount--
-        throw e
+        throw error
       .then =>
         @outstandingSaveCount--
         @setFile(file)


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/15267

It turns out that piping the buffer's text to the stdin of a child process created via the `spawn-as-admin` module was unreliable. I have decided to take a simpler approach to privilege escalation: it is now handled through a new module: [fs-admin](https://github.com/atom/fs-admin), which is tailored for performing specific file-system operations with elevated privileges. This way, on macOS we can use the [`authopen`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/authopen.1.html) for writing files.

I've also fixed a separate bug in superstring, related to handling save failures, which I discovered while testing the privilege escalation logic.