### PR TITLE
Fix translation of screen row queries in `DisplayMarkerLayer.findMarkers`

### DIFF
--- a/spec/display-marker-layer-spec.coffee
+++ b/spec/display-marker-layer-spec.coffee
@@ -316,6 +316,15 @@ describe "DisplayMarkerLayer", ->
       expect(markerLayer.findMarkers(class: 'a', startScreenRow: 0)).toEqual [marker1, marker2, marker3]
       expect(markerLayer.findMarkers(class: 'a', endScreenRow: 0)).toEqual [marker1, marker2, marker3]
 
+    it "allows the startsInBufferRange/endsInBufferRange and startsInScreenRange/endsInScreenRange to be specified", ->
+      marker1 = markerLayer.markBufferRange([[5, 2], [5, 4]], class: 'a')
+      marker2 = markerLayer.markBufferRange([[8, 0], [8, 2]], class: 'a')
+      displayLayer.foldBufferRange([[4, 0], [7, 0]])
+      expect(markerLayer.findMarkers(class: 'a', startsInBufferRange: [[5, 1], [5, 3]])).toEqual [marker1]
+      expect(markerLayer.findMarkers(class: 'a', endsInBufferRange: [[8, 1], [8, 3]])).toEqual [marker2]
+      expect(markerLayer.findMarkers(class: 'a', startsInScreenRange: [[4, 0], [4, 1]])).toEqual [marker1]
+      expect(markerLayer.findMarkers(class: 'a', endsInScreenRange: [[5, 1], [5, 3]])).toEqual [marker2]
+
     it "allows intersectsBufferRowRange to be specified", ->
       marker1 = markerLayer.markBufferRange([[5, 0], [5, 0]], class: 'a')
       marker2 = markerLayer.markBufferRange([[8, 0], [8, 0]], class: 'a')

--- a/spec/display-marker-layer-spec.coffee
+++ b/spec/display-marker-layer-spec.coffee
@@ -313,7 +313,8 @@ describe "DisplayMarkerLayer", ->
       displayLayer.destroyFoldsIntersectingBufferRange([[4, 0], [7, 0]])
       displayLayer.foldBufferRange([[0, 20], [12, 2]])
       marker3 = markerLayer.markBufferRange([[12, 0], [12, 0]], class: 'a')
-      expect(markerLayer.findMarkers(class: 'a', endScreenRow: 0)).toEqual [marker3]
+      expect(markerLayer.findMarkers(class: 'a', startScreenRow: 0)).toEqual [marker1, marker2, marker3]
+      expect(markerLayer.findMarkers(class: 'a', endScreenRow: 0)).toEqual [marker1, marker2, marker3]
 
     it "allows intersectsBufferRowRange to be specified", ->
       marker1 = markerLayer.markBufferRange([[5, 0], [5, 0]], class: 'a')
@@ -327,9 +328,15 @@ describe "DisplayMarkerLayer", ->
       displayLayer.foldBufferRange([[4, 0], [7, 0]])
       expect(markerLayer.findMarkers(class: 'a', intersectsScreenRowRange: [5, 10])).toEqual [marker2]
 
-      displayLayer.destroyFoldsIntersectingBufferRange([[4, 0], [7, 0]])
+      displayLayer.destroyAllFolds()
       displayLayer.foldBufferRange([[0, 20], [12, 2]])
       expect(markerLayer.findMarkers(class: 'a', intersectsScreenRowRange: [0, 0])).toEqual [marker1, marker2]
+
+      displayLayer.destroyAllFolds()
+      displayLayer.reset({softWrapColumn: 10})
+      marker1.setHeadScreenPosition([6, 5])
+      marker2.setHeadScreenPosition([9, 2])
+      expect(markerLayer.findMarkers(class: 'a', intersectsScreenRowRange: [5, 7])).toEqual [marker1]
 
     it "allows containedInScreenRange to be specified", ->
       marker1 = markerLayer.markBufferRange([[5, 0], [5, 0]], class: 'a')

--- a/spec/marker-spec.coffee
+++ b/spec/marker-spec.coffee
@@ -719,6 +719,12 @@ describe "Marker", ->
       expect(buffer.findMarkers(endPosition: [0, 7])).toEqual [marker4, marker3]
       expect(buffer.findMarkers(endPosition: [0, 7], class: 'b')).toEqual [marker4]
 
+    it "can find markers that start or end at a given range", ->
+      expect(buffer.findMarkers(startsInRange: [[0, 0], [0, 4]])).toEqual [marker4, marker2, marker1, marker3]
+      expect(buffer.findMarkers(startsInRange: [[0, 0], [0, 4]], class: 'a')).toEqual [marker2, marker1, marker3]
+      expect(buffer.findMarkers(startsInRange: [[0, 0], [0, 4]], endsInRange: [[0, 3], [0, 6]])).toEqual [marker2, marker1]
+      expect(buffer.findMarkers(endsInRange: [[0, 5], [0, 7]])).toEqual [marker4, marker2, marker3]
+
     it "can find markers that contain a given point", ->
       expect(buffer.findMarkers(containsPosition: [0, 0])).toEqual [marker4, marker2, marker1]
       expect(buffer.findMarkers(containsPoint: [0, 0])).toEqual [marker4, marker2, marker1]

--- a/src/display-marker-layer.coffee
+++ b/src/display-marker-layer.coffee
@@ -346,19 +346,23 @@ class DisplayMarkerLayer
         when 'endBufferRow'
           key = 'endRow'
         when 'startScreenRow'
-          key = 'startRow'
-          value = @displayLayer.translateScreenPosition(Point(value, 0)).row
+          key = 'startsInRange'
+          startBufferPosition = @displayLayer.translateScreenPosition(Point(value, 0))
+          endBufferPosition = @displayLayer.translateScreenPosition(Point(value, Infinity))
+          value = Range(startBufferPosition, endBufferPosition)
         when 'endScreenRow'
-          key = 'endRow'
-          value = @displayLayer.translateScreenPosition(Point(value, Infinity)).row
+          key = 'endsInRange'
+          startBufferPosition = @displayLayer.translateScreenPosition(Point(value, 0))
+          endBufferPosition = @displayLayer.translateScreenPosition(Point(value, Infinity))
+          value = Range(startBufferPosition, endBufferPosition)
         when 'intersectsBufferRowRange'
           key = 'intersectsRowRange'
         when 'intersectsScreenRowRange'
-          key = 'intersectsRowRange'
+          key = 'intersectsRange'
           [startScreenRow, endScreenRow] = value
-          startBufferRow = @displayLayer.translateScreenPosition(Point(startScreenRow, 0)).row
-          endBufferRow = @displayLayer.translateScreenPosition(Point(endScreenRow, Infinity)).row
-          value = [startBufferRow, endBufferRow]
+          startBufferPosition = @displayLayer.translateScreenPosition(Point(startScreenRow, 0))
+          endBufferPosition = @displayLayer.translateScreenPosition(Point(endScreenRow, Infinity))
+          value = Range(startBufferPosition, endBufferPosition)
         when 'containsBufferRange'
           key = 'containsRange'
         when 'containsScreenRange'

--- a/src/display-marker-layer.coffee
+++ b/src/display-marker-layer.coffee
@@ -275,6 +275,10 @@ class DisplayMarkerLayer
   #   * `endBufferPosition` Only include markers ending at this {Point} in buffer coordinates.
   #   * `startScreenPosition` Only include markers starting at this {Point} in screen coordinates.
   #   * `endScreenPosition` Only include markers ending at this {Point} in screen coordinates.
+  #   * `startsInBufferRange` Only include markers starting inside this {Range} in buffer coordinates.
+  #   * `endsInBufferRange` Only include markers ending inside this {Range} in buffer coordinates.
+  #   * `startsInScreenRange` Only include markers starting inside this {Range} in screen coordinates.
+  #   * `endsInScreenRange` Only include markers ending inside this {Range} in screen coordinates.
   #   * `startBufferRow` Only include markers starting at this row in buffer coordinates.
   #   * `endBufferRow` Only include markers ending at this row in buffer coordinates.
   #   * `startScreenRow` Only include markers starting at this row in screen coordinates.
@@ -341,6 +345,16 @@ class DisplayMarkerLayer
         when 'endScreenPosition'
           key = 'endPosition'
           value = @displayLayer.translateScreenPosition(value)
+        when 'startsInBufferRange'
+          key = 'startsInRange'
+        when 'endsInBufferRange'
+          key = 'endsInRange'
+        when 'startsInScreenRange'
+          key = 'startsInRange'
+          value = @displayLayer.translateScreenRange(value)
+        when 'endsInScreenRange'
+          key = 'endsInRange'
+          value = @displayLayer.translateScreenRange(value)
         when 'startBufferRow'
           key = 'startRow'
         when 'endBufferRow'

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -115,6 +115,12 @@ class MarkerLayer
           markerIds = filterSet(markerIds, @index.findStartingAt(Point.fromObject(value)))
         when 'endPosition'
           markerIds = filterSet(markerIds, @index.findEndingAt(Point.fromObject(value)))
+        when 'startsInRange'
+          {start, end} = Range.fromObject(value)
+          markerIds = filterSet(markerIds, @index.findStartingIn(start, end))
+        when 'endsInRange'
+          {start, end} = Range.fromObject(value)
+          markerIds = filterSet(markerIds, @index.findEndingIn(start, end))
         when 'containsPoint', 'containsPosition'
           position = Point.fromObject(value)
           markerIds = filterSet(markerIds, @index.findContaining(position, position))

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1086,6 +1086,8 @@ class TextBuffer
   #   have special semantics:
   #   * `startPosition` Only include markers that start at the given {Point}.
   #   * `endPosition` Only include markers that end at the given {Point}.
+  #   * `startsInRange` Only include markers that start inside the given {Range}.
+  #   * `endsInRange` Only include markers that end inside the given {Range}.
   #   * `containsPoint` Only include markers that contain the given {Point}, inclusive.
   #   * `containsRange` Only include markers that contain the given {Range}, inclusive.
   #   * `startRow` Only include markers that start at the given row {Number}.


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/15441

Previously, when querying a display marker layer with the `startScreenRow`, `endScreenRow` or `intersectsScreenRowRange` parameters, we would simply convert the supplied screen rows into buffer rows and then query the underlying buffer marker layer using the `startRow`, `endRow` or `intersectsRowRange` parameters.

This behavior was, however, incorrect. In fact, translating a screen row into a buffer row and using that to perform the query in the buffer marker layer caused the entire buffer row to be scanned. In presence of folds or soft-wraps, such query could completely distort the area to scan that the caller was interested in, and possibly return markers outside of it or hiding markers inside of it.

With this pull-request we are changing the translation strategy so that:

* `startScreenRow` queries are translated using the new `startsInRange` query parameter in the buffer marker layer.
* `endScreenRow` queries are translated using the new `endsInRange` query parameter in the buffer marker layer.
* `intersectsScreenRowRange` queries are translated using the `intersectsRange` query parameter in the buffer marker layer.

/cc: @nathansobo @maxbrunsfeld 