### PR TITLE
On destroy, don't clear native buffer until all saves are done

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.1.14",
+  "version": "13.1.15-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.1.14",
+  "version": "13.1.15-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -238,6 +238,18 @@ describe('TextBuffer IO', () => {
       })
     })
 
+    describe('when the buffer is destroyed before the save completes', () => {
+      it('saves the current contents of the buffer to the path', (done) => {
+        buffer.setText('hello\n')
+        buffer.save().then(() => {
+          expect(buffer.getText()).toBe('')
+          expect(fs.readFileSync(filePath, 'utf8')).toBe('hello\n')
+          done()
+        })
+        buffer.destroy()
+      })
+    })
+
     describe('when a conflict is created', () => {
       beforeEach((done) => {
         buffer.setText('a')

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1724,7 +1724,14 @@ class TextBuffer
       @fileSubscriptions?.dispose()
       for id, markerLayer of @markerLayers
         markerLayer.destroy()
-      @buffer.reset('')
+      if @outstandingSaveCount is 0
+        @buffer.reset('')
+      else
+        subscription = @onDidSave =>
+          if @outstandingSaveCount is 0
+            @buffer.reset('')
+            subscription.dispose()
+
       @cachedText = null
       @history.clear()
 


### PR DESCRIPTION
#### Problem

When a `TextBuffer` is destroyed, we clear out its state because it is common for Atom packages to accidentally cause buffers to be leaked, and we don't want these leaks to have large impacts on Atom's memory usage. But in certain scenarios, we destroy text buffers *while* they are still being saved. This case is [already handled correctly](https://github.com/atom/superstring/blob/a30e4de4906b2c879423fec814252a95f057fee3/test/js/text-buffer.test.js#L531) by the native text buffer, but there is [other async work](https://github.com/atom/text-buffer/blob/80ecaabede346a1613b1dd133efe67139ac3df9c/src/text-buffer.coffee#L1556) that we have to do *before* calling into the native buffer. The problem arises when we call *destroy* while this initial async work is happening.

#### Solution

When we destroy a buffer, if there is an outstanding save, we wait to clear out the buffer's state until that save is complete.

Fixes https://github.com/atom/autosave/issues/80