### PR TITLE
Allow custom history providers to be assigned

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -11,7 +11,7 @@ TextBuffer = require '../src/text-buffer'
 SampleText = fs.readFileSync(join(__dirname, 'fixtures', 'sample.js'), 'utf8')
 {buildRandomLines, getRandomBufferRange} = require './helpers/random'
 
-describe "TextBuffer", ->
+fdescribe "TextBuffer", ->
   buffer = null
 
   beforeEach ->
@@ -367,7 +367,7 @@ describe "TextBuffer", ->
       buffer.undo()
       expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
 
-    it "does not allow the undo stack to grow without bound", ->
+    xit "does not allow the undo stack to grow without bound", ->
       buffer = new TextBuffer(maxUndoEntries: 12)
 
       # Each transaction is treated as a single undo entry. We can undo up
@@ -535,6 +535,7 @@ describe "TextBuffer", ->
         expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
 
       it "groups adjacent transactions within each other's grouping intervals", ->
+        now += 1000
         buffer.transact 101, -> buffer.setTextInRange([[0, 2], [0, 5]], "y")
 
         now += 100
@@ -555,6 +556,7 @@ describe "TextBuffer", ->
 
         buffer.undo()
         expect(buffer.getText()).toBe "hello\nworms\r\nhow are you doing?"
+        return
 
         buffer.redo()
         expect(buffer.getText()).toBe "heyyyyy\nworms\r\nhow are you doing?"
@@ -2036,6 +2038,7 @@ describe "TextBuffer", ->
 
       buffer.insert([0, 0], "abc")
       buffer.delete([[0, 0], [0, 1]])
+
       assertChangesEqual(textChanges, [
         {
           oldRange: [[0, 0], [0, 0]],

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -826,7 +826,7 @@ describe "TextBuffer", ->
       buffer.undo()
       expect(buffer.getText()).toBe('Lorem ')
 
-      buffer.setHistoryProvider(new DefaultHistoryProvider())
+      buffer.setHistoryProvider(new DefaultHistoryProvider(buffer))
       buffer.undo()
       expect(buffer.getText()).toBe('Lorem ')
 

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -836,7 +836,7 @@ describe "TextBuffer", ->
       buffer.undo()
       expect(buffer.getText()).toBe('Lorem ')
 
-  describe "::getHistoryProviderSnapshot(maxEntries)", ->
+  describe "::getHistory(maxEntries)", ->
     it "returns a base text and the state of the last `maxEntries` entries in the undo and redo stacks", ->
       buffer = new TextBuffer({text: ''})
       markerLayer = buffer.addMarkerLayer({maintainHistory: true})
@@ -859,7 +859,7 @@ describe "TextBuffer", ->
       buffer.undo()
       buffer.undo()
 
-      {baseText, nextCheckpointId, undoStack, redoStack} = buffer.getHistoryProviderSnapshot(3)
+      {baseText, nextCheckpointId, undoStack, redoStack} = buffer.getHistory(3)
       expect(baseText).toBe('Lorem ipsum dolor ')
       expect(nextCheckpointId).toBe(buffer.createCheckpoint())
       expect(undoStack).toEqual([
@@ -906,7 +906,7 @@ describe "TextBuffer", ->
     it "throws an error when called within a transaction", ->
       buffer = new TextBuffer()
       expect(->
-        buffer.transact(-> buffer.getHistoryProviderSnapshot(3))
+        buffer.transact(-> buffer.getHistory(3))
       ).toThrowError()
 
   describe "::getTextInRange(range)", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2045,17 +2045,18 @@ describe "TextBuffer", ->
 
       textChanges = []
       buffer.transact ->
-        buffer.insert([1, 0], "x")
-        buffer.insert([1, 1], "y")
+        buffer.insert([1, 0], "v")
+        buffer.insert([1, 1], "x")
+        buffer.setTextInRange([[1, 2], [1, 2]], "y", {undo: 'skip'})
         buffer.insert([2, 3], "zw")
         buffer.delete([[2, 3], [2, 4]])
 
       assertChangesEqual(textChanges, [
         {
           oldRange: [[1, 0], [1, 0]],
-          newRange: [[1, 0], [1, 2]],
+          newRange: [[1, 0], [1, 3]],
           oldText: "",
-          newText: "xy",
+          newText: "vxy",
         },
         {
           oldRange: [[2, 3], [2, 3]],
@@ -2071,7 +2072,7 @@ describe "TextBuffer", ->
         {
           oldRange: [[1, 0], [1, 2]],
           newRange: [[1, 0], [1, 0]],
-          oldText: "xy",
+          oldText: "vx",
           newText: "",
         },
         {
@@ -2089,7 +2090,7 @@ describe "TextBuffer", ->
           oldRange: [[1, 0], [1, 0]],
           newRange: [[1, 0], [1, 2]],
           oldText: "",
-          newText: "xy",
+          newText: "vx",
         },
         {
           oldRange: [[2, 3], [2, 3]],
@@ -2146,6 +2147,7 @@ describe "TextBuffer", ->
           buffer.transact ->
             buffer.insert([0, 0], 'b')
             buffer.insert([1, 0], 'c')
+            buffer.setTextInRange([[1, 1], [1, 1]], 'd', {undo: 'skip'})
         expect(didStopChangingCallback).not.toHaveBeenCalled()
 
         wait delay / 2, ->
@@ -2162,10 +2164,10 @@ describe "TextBuffer", ->
               },
               {
                 oldRange: [[1, 0], [1, 0]],
-                newRange: [[1, 0], [1, 1]],
+                newRange: [[1, 0], [1, 2]],
                 oldText: "",
-                newText: "c",
-              },
+                newText: "cd",
+              }
             ])
 
             didStopChangingCallback.calls.reset()

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -903,6 +903,12 @@ describe "TextBuffer", ->
         }
       ])
 
+    it "throws an error when called within a transaction", ->
+      buffer = new TextBuffer()
+      expect(->
+        buffer.transact(-> buffer.getHistoryProviderSnapshot(3))
+      ).toThrowError()
+
   describe "::getTextInRange(range)", ->
     it "returns the text in a given range", ->
       buffer = new TextBuffer(text: "hello\nworld\r\nhow are you doing?")

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -6,12 +6,12 @@ Random = require 'random-seed'
 Point = require '../src/point'
 Range = require '../src/range'
 DisplayLayer = require '../src/display-layer'
-DefaultHistoryProvider = require '../src/history'
+DefaultHistoryProvider = require '../src/default-history-provider'
 TextBuffer = require '../src/text-buffer'
 SampleText = fs.readFileSync(join(__dirname, 'fixtures', 'sample.js'), 'utf8')
 {buildRandomLines, getRandomBufferRange} = require './helpers/random'
 
-fdescribe "TextBuffer", ->
+describe "TextBuffer", ->
   buffer = null
 
   beforeEach ->
@@ -367,7 +367,7 @@ fdescribe "TextBuffer", ->
       buffer.undo()
       expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
 
-    xit "does not allow the undo stack to grow without bound", ->
+    it "does not allow the undo stack to grow without bound", ->
       buffer = new TextBuffer(maxUndoEntries: 12)
 
       # Each transaction is treated as a single undo entry. We can undo up

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -818,34 +818,23 @@ fdescribe "TextBuffer", ->
 
   describe "::setHistoryProvider(provider)", ->
     it "replaces the currently active history provider with the passed one", ->
-      buffer = new TextBuffer({text: '', maxUndoEntries: 7})
-      oldHistoryProvider = buffer.getHistoryProvider()
-      newHistoryProvider = new DefaultHistoryProvider()
-      buffer.setHistoryProvider(newHistoryProvider)
-      expect(newHistoryProvider.buffer).toBe(buffer)
-      expect(newHistoryProvider.maxUndoEntries).toBe(7)
-
+      buffer = new TextBuffer({text: ''})
       buffer.insert([0, 0], 'Lorem ')
       buffer.insert([0, 6], 'ipsum ')
-      buffer.insert([0, 12], 'dolor')
-      expect(buffer.getText()).toBe('Lorem ipsum dolor')
-      expect(oldHistoryProvider.undoStack.length).toBe(0)
-      expect(oldHistoryProvider.redoStack.length).toBe(0)
-
-      buffer.undo()
       expect(buffer.getText()).toBe('Lorem ipsum ')
-      expect(oldHistoryProvider.undoStack.length).toBe(0)
-      expect(oldHistoryProvider.redoStack.length).toBe(0)
 
       buffer.undo()
       expect(buffer.getText()).toBe('Lorem ')
-      expect(oldHistoryProvider.undoStack.length).toBe(0)
-      expect(oldHistoryProvider.redoStack.length).toBe(0)
 
-      buffer.redo()
-      expect(buffer.getText()).toBe('Lorem ipsum ')
-      expect(oldHistoryProvider.undoStack.length).toBe(0)
-      expect(oldHistoryProvider.redoStack.length).toBe(0)
+      buffer.setHistoryProvider(new DefaultHistoryProvider())
+      buffer.undo()
+      expect(buffer.getText()).toBe('Lorem ')
+
+      buffer.insert([0, 6], 'dolor ')
+      expect(buffer.getText()).toBe('Lorem dolor ')
+
+      buffer.undo()
+      expect(buffer.getText()).toBe('Lorem ')
 
   describe "::getTextInRange(range)", ->
     it "returns the text in a given range", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -556,7 +556,6 @@ describe "TextBuffer", ->
 
         buffer.undo()
         expect(buffer.getText()).toBe "hello\nworms\r\nhow are you doing?"
-        return
 
         buffer.redo()
         expect(buffer.getText()).toBe "heyyyyy\nworms\r\nhow are you doing?"

--- a/src/default-history-provider.coffee
+++ b/src/default-history-provider.coffee
@@ -149,8 +149,8 @@ class DefaultHistoryProvider
     if spliceIndex?
       @redoStack.push(@undoStack.splice(spliceIndex).reverse()...)
       {
+        textUpdates: patch.getChanges()
         markers: snapshotBelow
-        changes: patch.getChanges()
       }
     else
       false
@@ -183,8 +183,8 @@ class DefaultHistoryProvider
     if spliceIndex?
       @undoStack.push(@redoStack.splice(spliceIndex).reverse()...)
       {
+        textUpdates: patch.getChanges()
         markers: snapshotBelow
-        changes: patch.getChanges()
       }
     else
       false
@@ -212,8 +212,8 @@ class DefaultHistoryProvider
     if spliceIndex?
       @undoStack.splice(spliceIndex)
       {
+        textUpdates: Patch.compose(patchesSinceCheckpoint).getChanges()
         markers: snapshotBelow
-        changes: Patch.compose(patchesSinceCheckpoint).getChanges()
       }
     else
       false

--- a/src/default-history-provider.coffee
+++ b/src/default-history-provider.coffee
@@ -1,6 +1,7 @@
 {Patch} = require 'superstring'
 MarkerLayer = require './marker-layer'
 {traversal} = require './point-helpers'
+{patchFromChanges} = require './helpers'
 
 SerializationVersion = 6
 
@@ -395,11 +396,5 @@ snapshotFromTransaction = (transaction) ->
   }
 
 transactionFromSnapshot = ({changes, markersBefore, markersAfter}) ->
-  patch = new Patch
-  for {oldStart, oldEnd, oldText, newStart, newEnd, newText} in changes by -1
-    oldExtent = traversal(oldEnd, oldStart)
-    newExtent = traversal(newEnd, newStart)
-    patch.splice(oldStart, oldExtent, newExtent, oldText, newText)
-
   # TODO: Return raw patch if there's no markersBefore && markersAfter
-  new Transaction(markersBefore, patch, markersAfter)
+  new Transaction(markersBefore, patchFromChanges(changes), markersAfter)

--- a/src/default-history-provider.coffee
+++ b/src/default-history-provider.coffee
@@ -28,9 +28,7 @@ class Transaction
 # Manages undo/redo for {TextBuffer}
 module.exports =
 class DefaultHistoryProvider
-  constructor: ->
-
-  initialize: (@buffer) ->
+  constructor: (@buffer) ->
     @maxUndoEntries = @buffer.maxUndoEntries
     @nextCheckpointId = 1
     @undoStack = []

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,6 @@
+const {Patch} = require('superstring')
 const Range = require('./range')
+const {traversal} = require('./point-helpers')
 
 const NEWLINE_REGEX = /\n/g
 const MULTI_LINE_REGEX_REGEX = /\\s|\\r|\\n|\r|\n|^\[\^|[^\\]\[\^/
@@ -50,6 +52,17 @@ exports.spliceArray = function (array, start, removedCount, insertedItems = []) 
   for (let i = 0; i < insertedItems.length; i++) {
     array[start + i] = insertedItems[i]
   }
+}
+
+exports.patchFromChanges = function (changes) {
+  const patch = new Patch()
+  for (let i = 0; i < changes.length; i++) {
+    const {oldStart, oldEnd, oldText, newStart, newEnd, newText} = changes[i]
+    const oldExtent = traversal(oldEnd, oldStart)
+    const newExtent = traversal(newEnd, newStart)
+    patch.splice(newStart, oldExtent, newExtent, oldText, newText)
+  }
+  return patch
 }
 
 exports.normalizePatchChanges = function (changes) {

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -28,7 +28,7 @@ class Transaction
 # Manages undo/redo for {TextBuffer}
 module.exports =
 class History
-  constructor: () ->
+  constructor: ->
 
   initialize: (buffer) ->
     @buffer = buffer

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -28,7 +28,11 @@ class Transaction
 # Manages undo/redo for {TextBuffer}
 module.exports =
 class History
-  constructor: (@buffer, @maxUndoEntries) ->
+  constructor: () ->
+
+  initialize: (buffer) ->
+    @buffer = buffer
+    @maxUndoEntries = buffer.maxUndoEntries
     @nextCheckpointId = 1
     @undoStack = []
     @redoStack = []

--- a/src/history.coffee
+++ b/src/history.coffee
@@ -28,7 +28,10 @@ class Transaction
 # Manages undo/redo for {TextBuffer}
 module.exports =
 class History
-  constructor: (@buffer, @maxUndoEntries) ->
+  constructor: (parameters...) ->
+    @initialize(parameters...)
+
+  initialize: (@buffer, @maxUndoEntries) ->
     @nextCheckpointId = 0
     @undoStack = []
     @redoStack = []

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -384,6 +384,7 @@ class MarkerLayer
   ###
 
   addMarker: (id, range, params) ->
+    range = Range.fromObject(range)
     Point.assertValid(range.start)
     Point.assertValid(range.end)
     @index.insert(id, range.start, range.end)

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -343,6 +343,9 @@ class Marker
   update: (oldRange, {range, reversed, tailed, valid, exclusive, properties}, textChanged=false, suppressMarkerLayerUpdateEvents=false) ->
     return if @isDestroyed()
 
+    oldRange = Range.fromObject(oldRange)
+    range = Range.fromObject(range) if range?
+
     wasExclusive = @isExclusive()
     updated = propertiesChanged = false
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1116,6 +1116,21 @@ class TextBuffer
   setHistoryProvider: (historyProvider) ->
     @history = historyProvider
 
+  getHistoryProviderSnapshot: (maxEntries) ->
+    snapshot = @history.getSnapshot(maxEntries)
+
+    baseTextBuffer = new NativeTextBuffer(@getText())
+    for change in snapshot.undoStackChanges by -1
+      newRange = Range(change.newStart, change.newEnd)
+      baseTextBuffer.setTextInRange(newRange, change.oldText)
+
+    {
+      baseText: baseTextBuffer.getText(),
+      undoStack: snapshot.undoStack,
+      redoStack: snapshot.redoStack,
+      nextCheckpointId: snapshot.nextCheckpointId
+    }
+
   # Public: Undo the last operation. If a transaction is in progress, aborts it.
   undo: ->
     if pop = @history.undo()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -42,10 +42,14 @@ class HistoryShim
     @clearRedoStack()
 
   undo: ->
-    @history.undo()
+    entry = @history.undo()
+    if entry
+      {changes: entry.textUpdates}
 
   redo: ->
-    @history.redo()
+    entry = @history.redo()
+    if entry
+      {changes: entry.textUpdates}
 
   createCheckpoint: (props) ->
     @history.createCheckpoint(props)
@@ -57,7 +61,11 @@ class HistoryShim
     @history.getChangesSinceCheckpoint(checkpoint)
 
   revertToCheckpoint: (checkpoint, options) ->
-    @history.revertToCheckpoint(checkpoint, options)
+    result = @history.revertToCheckpoint(checkpoint, options)
+    if result
+      {changes: result.textUpdates}
+    else
+      result
 
   applyGroupingInterval: (interval) ->
     @history.applyGroupingInterval(interval)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -208,10 +208,6 @@ class TextBuffer
     @history = new History(this, @maxUndoEntries)
 
 
-    replica = new DocumentReplica(1)
-    replica.setTextInRange({row: 0, column: 0}, {row: 0, column: 0}, @getText())
-    replica.clearUndoStack()
-    @setHistoryProvider(replica)
 
 
     @nextMarkerLayerId = 0
@@ -224,6 +220,8 @@ class TextBuffer
     @nextMarkerId = 1
     @outstandingSaveCount = 0
     @loadCount = 0
+
+    @setHistoryProvider(@buildDocumentReplica(@getText()))
 
     @setEncoding(params?.encoding)
     @setPreferredLineEnding(params?.preferredLineEnding)
@@ -1695,10 +1693,7 @@ class TextBuffer
 
     @finishLoading(changeEvent, checkpoint, patch)
 
-    replica = new DocumentReplica(1)
-    replica.setTextInRange({row: 0, column: 0}, {row: 0, column: 0}, @getText())
-    replica.clearUndoStack()
-    @setHistoryProvider(replica)
+    @setHistoryProvider(@buildDocumentReplica(@getText()))
 
   load: (options) ->
     unless options?.internal
@@ -1916,6 +1911,12 @@ class TextBuffer
       line = @lineForRow(row)
       console.log row, line, line.length
     return
+
+  buildDocumentReplica: (text) ->
+    replica = new DocumentReplica(1)
+    replica.setTextInRange({row: 0, column: 0}, {row: 0, column: 0}, text)
+    replica.clearUndoStack()
+    replica
 
   ###
   Section: Private History Delegate Methods

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -19,7 +19,7 @@ DisplayLayer = require './display-layer'
 Grim = require 'grim'
 
 class HistoryShim
-  constructor: () ->
+  constructor: ->
 
   initialize: (buffer) ->
     @history = new DocumentReplica(1)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -164,7 +164,7 @@ class TextBuffer
     @debouncedEmitDidStopChangingEvent = debounce(@emitDidStopChangingEvent.bind(this), @stoppedChangingDelay)
     @textDecorationLayers = new Set()
     @maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
-    @setHistoryProvider(new DefaultHistoryProvider())
+    @setHistoryProvider(new DefaultHistoryProvider(this))
     @nextMarkerLayerId = 0
     @nextDisplayLayerId = 0
     @defaultMarkerLayer = new MarkerLayer(this, String(@nextMarkerLayerId++))
@@ -1114,7 +1114,6 @@ class TextBuffer
   getHistoryProvider: -> @history
 
   setHistoryProvider: (historyProvider) ->
-    historyProvider.initialize(this)
     @history = historyProvider
 
   # Public: Undo the last operation. If a transaction is in progress, aborts it.

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -204,12 +204,6 @@ class TextBuffer
     @buffer = new NativeTextBuffer(text)
     @debouncedEmitDidStopChangingEvent = debounce(@emitDidStopChangingEvent.bind(this), @stoppedChangingDelay)
     @textDecorationLayers = new Set()
-    @maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
-    @history = new History(this, @maxUndoEntries)
-
-
-
-
     @nextMarkerLayerId = 0
     @nextDisplayLayerId = 0
     @defaultMarkerLayer = new MarkerLayer(this, String(@nextMarkerLayerId++))

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1122,6 +1122,11 @@ class TextBuffer
   setHistoryProvider: (historyProvider) ->
     @historyProvider = historyProvider
 
+  restoreDefaultHistoryProvider: (history) ->
+    provider = new DefaultHistoryProvider(this)
+    provider.restoreFromSnapshot(history)
+    @setHistoryProvider(provider)
+
   getHistory: (maxEntries) ->
     if @transactCallDepth > 0
       throw new Error('Cannot build history snapshots within transactions')

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1122,7 +1122,7 @@ class TextBuffer
   setHistoryProvider: (historyProvider) ->
     @historyProvider = historyProvider
 
-  getHistoryProviderSnapshot: (maxEntries) ->
+  getHistory: (maxEntries) ->
     if @transactCallDepth > 0
       throw new Error('Cannot build history snapshots within transactions')
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -10,7 +10,6 @@ mkdirp = require 'mkdirp'
 Point = require './point'
 Range = require './range'
 DefaultHistoryProvider = require './default-history-provider'
-{Document} = require '@atom/tachyon'
 MarkerLayer = require './marker-layer'
 MatchIterator = require './match-iterator'
 DisplayLayer = require './display-layer'
@@ -1113,8 +1112,6 @@ class TextBuffer
   ###
   Section: History
   ###
-
-  getHistoryProvider: -> @history
 
   setHistoryProvider: (historyProvider) ->
     @history = historyProvider

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -18,7 +18,6 @@ DisplayLayer = require './display-layer'
 {traversal} = require './point-helpers'
 Grim = require 'grim'
 
-
 class HistoryShim
   constructor: () ->
 
@@ -221,6 +220,9 @@ class TextBuffer
     @buffer = new NativeTextBuffer(text)
     @debouncedEmitDidStopChangingEvent = debounce(@emitDidStopChangingEvent.bind(this), @stoppedChangingDelay)
     @textDecorationLayers = new Set()
+    @maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
+    # @setHistoryProvider(new DefaultHistoryProvider())
+    @setHistoryProvider(new HistoryShim())
     @nextMarkerLayerId = 0
     @nextDisplayLayerId = 0
     @defaultMarkerLayer = new MarkerLayer(this, String(@nextMarkerLayerId++))
@@ -231,10 +233,6 @@ class TextBuffer
     @nextMarkerId = 1
     @outstandingSaveCount = 0
     @loadCount = 0
-
-    @maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
-    # @setHistoryProvider(new DefaultHistoryProvider())
-    @setHistoryProvider(new HistoryShim())
 
     @setEncoding(params?.encoding)
     @setPreferredLineEnding(params?.preferredLineEnding)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1778,7 +1778,7 @@ class TextBuffer
       @emitDidChangeEvent(changeEvent)
       markerSnapshot = @createMarkerSnapshot()
       @history.groupChangesSinceCheckpoint(checkpoint, {markerSnapshot: markerSnapshot, deleteCheckpoint: true})
-      @emitDidChangeTextEvent(patch)
+      @emitDidChangeTextEvent(patch.getChanges())
       @emitMarkerChangeEvents(markerSnapshot)
       @emitModifiedStatusChanged(@isModified())
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1269,7 +1269,7 @@ class TextBuffer
   #
   # Returns a {Boolean} indicating whether the operation succeeded.
   groupChangesSinceCheckpoint: (checkpoint) ->
-    @history.groupChangesSinceCheckpoint(checkpoint, @createMarkerSnapshot(), false)
+    @history.groupChangesSinceCheckpoint(checkpoint, {markerSnapshot: @createMarkerSnapshot(), deleteCheckpoint: false})
 
   # Public: Returns a list of changes since the given checkpoint.
   #
@@ -1762,7 +1762,7 @@ class TextBuffer
       changeEvent.didChange = true
       @emitDidChangeEvent(changeEvent)
       markerSnapshot = @createMarkerSnapshot()
-      @history.groupChangesSinceCheckpoint(checkpoint, markerSnapshot, true)
+      @history.groupChangesSinceCheckpoint(checkpoint, {markerSnapshot: markerSnapshot, deleteCheckpoint: true})
       @emitDidChangeTextEvent(patch)
       @emitMarkerChangeEvents(markerSnapshot)
       @emitModifiedStatusChanged(@isModified())

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1695,6 +1695,11 @@ class TextBuffer
 
     @finishLoading(changeEvent, checkpoint, patch)
 
+    replica = new DocumentReplica(1)
+    replica.setTextInRange({row: 0, column: 0}, {row: 0, column: 0}, @getText())
+    replica.clearUndoStack()
+    @setHistoryProvider(replica)
+
   load: (options) ->
     unless options?.internal
       Grim.deprecate('The .load instance method is deprecated. Create a loaded buffer using TextBuffer.load(filePath) instead.')
@@ -1766,6 +1771,12 @@ class TextBuffer
       @emitDidChangeTextEvent(patch)
       @emitMarkerChangeEvents(markerSnapshot)
       @emitModifiedStatusChanged(@isModified())
+
+    unless @loaded
+      start = {row: 0, column: 0}
+      end = {row: 0, column: 0}
+      # TODO Remove Demeter violation
+      @history.history.setTextInRange(start, end, @getText())
 
     @loaded = true
     @emitter.emit('did-reload')

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1239,7 +1239,7 @@ class TextBuffer
   #
   # Returns a checkpoint value.
   createCheckpoint: ->
-    @history.createCheckpoint(@createMarkerSnapshot(), false)
+    @history.createCheckpoint(markerSnapshot: @createMarkerSnapshot(), isBarrier: false)
 
   # Public: Revert the buffer to the state it was in when the given
   # checkpoint was created.
@@ -1682,7 +1682,7 @@ class TextBuffer
         (percentDone, patch) =>
           if patch and patch.getChangeCount() > 0
             changeEvent = new CompositeChangeEvent(@buffer, patch)
-            checkpoint = @history.createCheckpoint(@createMarkerSnapshot(), true)
+            checkpoint = @history.createCheckpoint(markerSnapshot: @createMarkerSnapshot(), isBarrier: true)
             @emitter.emit('will-reload')
             @emitter.emit('will-change', changeEvent)
       )
@@ -1719,7 +1719,7 @@ class TextBuffer
         if patch
           if patch.getChangeCount() > 0
             changeEvent = new CompositeChangeEvent(@buffer, patch)
-            checkpoint = @history.createCheckpoint(@createMarkerSnapshot(), true)
+            checkpoint = @history.createCheckpoint(markerSnapshot: @createMarkerSnapshot(), isBarrier: true)
             @emitter.emit('will-reload')
             @emitter.emit('will-change', changeEvent)
           else if options?.discardChanges

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1707,8 +1707,6 @@ class TextBuffer
 
     @finishLoading(changeEvent, checkpoint, patch)
 
-    @setHistoryProvider(new HistoryShim())
-
   load: (options) ->
     unless options?.internal
       Grim.deprecate('The .load instance method is deprecated. Create a loaded buffer using TextBuffer.load(filePath) instead.')
@@ -1789,6 +1787,8 @@ class TextBuffer
       end = {row: 0, column: 0}
       # TODO Remove Demeter violation
       @history.history.setTextInRange(start, end, @getText())
+
+      @setHistoryProvider(new HistoryShim())
 
     @loaded = true
     @emitter.emit('did-reload')

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1897,7 +1897,19 @@ class TextBuffer
     return if @destroyed
 
     modifiedStatus = @isModified()
-    composedChanges = Patch.compose(@changesSinceLastStoppedChangingEvent).getChanges()
+
+    patches = @changesSinceLastStoppedChangingEvent.map (change) ->
+      patch = new Patch
+      patch.splice(
+        change.newStart,
+        extentForText(change.oldText),
+        extentForText(change.newText),
+        change.oldText,
+        change.newText
+      )
+      patch
+
+    composedChanges = Patch.compose(patches).getChanges()
     @emitter.emit(
       'did-stop-changing',
       {changes: Object.freeze(normalizePatchChanges(composedChanges))}

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -162,8 +162,8 @@ class TextBuffer
     @buffer = new NativeTextBuffer(text)
     @debouncedEmitDidStopChangingEvent = debounce(@emitDidStopChangingEvent.bind(this), @stoppedChangingDelay)
     @textDecorationLayers = new Set()
-    maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
-    @history = new History(this, maxUndoEntries)
+    @maxUndoEntries = params?.maxUndoEntries ? @defaultMaxUndoEntries
+    @history = new History(this, @maxUndoEntries)
     @nextMarkerLayerId = 0
     @nextDisplayLayerId = 0
     @defaultMarkerLayer = new MarkerLayer(this, String(@nextMarkerLayerId++))
@@ -1109,6 +1109,10 @@ class TextBuffer
   ###
   Section: History
   ###
+
+  setHistoryProvider: (historyProvider) ->
+    historyProvider.initialize(this, @maxUndoEntries)
+    @history = historyProvider
 
   # Public: Undo the last operation. If a transaction is in progress, aborts it.
   undo: ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1117,6 +1117,9 @@ class TextBuffer
     @history = historyProvider
 
   getHistoryProviderSnapshot: (maxEntries) ->
+    if @transactCallDepth > 0
+      throw new Error('Cannot build history snapshots within transactions')
+
     snapshot = @history.getSnapshot(maxEntries)
 
     baseTextBuffer = new NativeTextBuffer(@getText())


### PR DESCRIPTION
This PR adds the following major methods:

* `setHistoryProvider` This method takes an object that can serve as the history implementation for the buffer.
* `getHistory` This returns data about the current state of the history so that a new history provider can be pre-populated and provide continuity from the previous provider.
* `restoreDefaultHistoryProvider` This takes a similar history snapshot to re-populate the history of the default provider.

@as-cii I realized we should probably add some documentation for these methods before merging this. I'll try to get that done later today.