### PR TITLE
Calculate `newEnd` correctly when line ending normalization takes place

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -213,6 +213,30 @@ describe "TextBuffer", ->
           expect(buffer.lineEndingForRow(6)).toBe ''
           expect(changeEvents[1].newText).toBe "ms\r\ndo you\r\nlike\r\ndirt"
 
+          buffer.setTextInRange([[5, 1], [5, 3]], '\r')
+          expect(changeEvents[2]).toEqual({
+            oldRange: [[5, 1], [5, 3]],
+            newRange: [[5, 1], [6, 0]],
+            oldText: 'ik',
+            newText: '\r\n'
+          })
+
+          buffer.undo()
+          expect(changeEvents[3]).toEqual({
+            oldRange: [[5, 1], [6, 0]],
+            newRange: [[5, 1], [5, 3]],
+            oldText: '\r\n',
+            newText: 'ik'
+          })
+
+          buffer.redo()
+          expect(changeEvents[4]).toEqual({
+            oldRange: [[5, 1], [5, 3]],
+            newRange: [[5, 1], [6, 0]],
+            oldText: 'ik',
+            newText: '\r\n'
+          })
+
       describe "when the range's start row has no line ending (because it's the last line of the buffer)", ->
         describe "when the buffer contains no newlines", ->
           it "honors the newlines in the inserted text", ->


### PR DESCRIPTION
As part of https://github.com/atom/text-buffer/pull/255, we changed the way the `onDidChangeText` and `onDidStopChanging` collected changes so that they could avoid relying on the history (see 8a4a4d8 for more background).

Later, in ce1964f, we improved the performance of combining the accumulated changes by also storing the change's `newEnd`. This was, however, slightly incorrect, as we calculated such coordinate before normalizing line endings, thus causing the various text change events to start reporting inaccurate information.

With this pull-request we are fixing that oversight (adding also test coverage to ensure we don't regress in the future), as well as streamlining `applyChange`. In particular, we will now take care of normalizing lines in `setTextInRange` instead of `applyChange`, as that's the only call site in which normalization needs to take place.

/cc: @nathansobo 