### PR TITLE
Optionally fail to load buffers from missing files

### DIFF
--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -43,6 +43,15 @@ describe('TextBuffer IO', () => {
       })
     })
 
+    it('optionally rejects with an ENOENT if there is no file at the given path', (done) => {
+      const filePath = 'does-not-exist.txt'
+      TextBuffer.load(filePath, {mustExist: true}).then(() => {
+        expect('Did not fail with mustExist: true').toBeUndefined()
+      }, (err) => {
+        expect(err.code).toBe('ENOENT')
+      }).then(done)
+    })
+
     describe('when a custom File object is given in place of the file path', () => {
       it('loads the buffer using the file\s createReadStream method', (done) => {
         const filePath = temp.openSync('atom').path
@@ -70,6 +79,14 @@ describe('TextBuffer IO', () => {
     it('returns an empty buffer if the file does not exist', () => {
       const buffer = TextBuffer.loadSync('/this/does/not/exist')
       expect(buffer.getText()).toBe('')
+    })
+
+    it('optionally throws ENOENT if there is no file at the given path', () => {
+      try {
+        TextBuffer.loadSync('/does-not-exist.txt', {mustExist: true})
+      } catch (e) {
+        expect(e.code).toBe('ENOENT')
+      }
     })
   })
 

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -84,6 +84,7 @@ describe('TextBuffer IO', () => {
     it('optionally throws ENOENT if there is no file at the given path', () => {
       try {
         TextBuffer.loadSync('/does-not-exist.txt', {mustExist: true})
+        expect('Did not fail with mustExist: true').toBeUndefined()
       } catch (e) {
         expect(e.code).toBe('ENOENT')
       }

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1179,6 +1179,22 @@ describe "TextBuffer", ->
 
       expect(TextBuffer.deserialize(serializedBuffer)).toBeUndefined()
 
+    it "doesn't deserialize a state referencing a file that no longer exists", (done) ->
+      tempDir = fs.realpathSync(temp.mkdirSync('text-buffer'))
+      filePath = join(tempDir, 'file.txt')
+      fs.writeFileSync(filePath, "something\n")
+
+      bufferA = TextBuffer.loadSync(filePath)
+      state = bufferA.serialize()
+
+      fs.unlinkSync(filePath)
+
+      state.mustExist = true
+      TextBuffer.deserialize(state).then(
+        () -> expect('serialization succeeded with mustExist: true').toBeUndefined(),
+        (err) -> expect(err.code).toBe('ENOENT')
+      ).then(done, done)
+
     describe "when the serialized buffer was unsaved and had no path", ->
       it "restores the previous unsaved state of the buffer", ->
         buffer = new TextBuffer()

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1191,7 +1191,7 @@ describe "TextBuffer", ->
 
       state.mustExist = true
       TextBuffer.deserialize(state).then(
-        () -> expect('serialization succeeded with mustExist: true').toBeUndefined(),
+        -> expect('serialization succeeded with mustExist: true').toBeUndefined(),
         (err) -> expect(err.code).toBe('ENOENT')
       ).then(done, done)
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -220,7 +220,7 @@ class TextBuffer
       buffer.setPath(source)
     else
       buffer.setFile(source)
-    buffer.load(clearHistory: true, internal: true).then -> buffer
+    buffer.load(clearHistory: true, internal: true, mustExist: params?.mustExist).then -> buffer
 
   # Public: Create a new buffer backed by the given file path. For better
   # performance, use {TextBuffer.load} instead.
@@ -236,7 +236,7 @@ class TextBuffer
   @loadSync: (filePath, params) ->
     buffer = new TextBuffer(params)
     buffer.setPath(filePath)
-    buffer.loadSync(internal: true)
+    buffer.loadSync(internal: true, mustExist: params?.mustExist)
     buffer
 
   # Public: Restore a {TextBuffer} based on an earlier state created using
@@ -1662,7 +1662,7 @@ class TextBuffer
             @emitter.emit('will-change', changeEvent)
       )
     catch error
-      if error.code is 'ENOENT'
+      if not options.mustExist and error.code is 'ENOENT'
         @emitter.emit('did-reload')
         @setText('') if options?.discardChanges
       else
@@ -1702,7 +1702,7 @@ class TextBuffer
     ).then((patch) =>
       @finishLoading(changeEvent, checkpoint, patch, options)
     ).catch((error) =>
-      if options.mustExist and error.code is 'ENOENT'
+      if not options?.mustExist and error.code is 'ENOENT'
         @emitter.emit('will-reload')
         @setText('') if options?.discardChanges
         @emitter.emit('did-reload')

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1702,7 +1702,7 @@ class TextBuffer
     ).then((patch) =>
       @finishLoading(changeEvent, checkpoint, patch, options)
     ).catch((error) =>
-      if error.code is 'ENOENT'
+      if options.mustExist and error.code is 'ENOENT'
         @emitter.emit('will-reload')
         @setText('') if options?.discardChanges
         @emitter.emit('did-reload')


### PR DESCRIPTION
By default, `TextBuffer` will deserialize or load files that do not exist as empty buffers. As a consequence, when you open Atom after deleting or moving a file that was open in an editor in a previous session (or checking out a different git branch, or unmounting a drive...) your workspace is created with empty TextEditors.

We also have some time-of-check, time-of-use race conditions in `Project` deserialization that are caused by needing to detect certain failure conditions before calling `TextBuffer.deserialize()`.

This adds a `mustExist:` option to `TextBuffer`'s load and deserialization methods that cause the ENOENT error to propagate to the caller, which can then report it or skip it based on higher-level abstraction logic.

Prerequisite for the last bits of atom/atom#15681.