### PR TITLE
Emit text and marker change events when skipping undo

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -837,7 +837,13 @@ class TextBuffer
       newStart: oldRange.start, newEnd: traverse(oldRange.start, extentForText(newText))
       oldText, newText
     }
-    @applyChange(change, undo isnt 'skip')
+    newRange = @applyChange(change, undo isnt 'skip')
+
+    if @transactCallDepth is 0 and undo is 'skip'
+      @emitDidChangeTextEvent()
+      @emitMarkerChangeEvents()
+
+    newRange
 
   # Public: Insert text at the given position.
   #


### PR DESCRIPTION
Back in #255 we introduced a regression that prevented the following events from firing when calling `setTextInRange` with `undo: 'skip'`: 

* `buffer.onDidChangeText`
* `buffer.onDidStopChanging`
* `markerLayer.onDidUpdate`
* `marker.onDidChange`

This pull-request fixes it by calling `emitMarkerChangeEvents` and `emitDidChangeTextEvent` at the end of `setTextInRange` if the transact call depth is `0` and `undo` is `'skip'`.

/cc: @nathansobo 