### PR TITLE
Only You Can Prevent Pathwatcher Leaks

### DIFF
--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -58,7 +58,7 @@ describe('TextBuffer IO', () => {
         expect('Did not fail with mustExist: true').toBeUndefined()
       }, (err) => {
         expect(err.code).toBe('ENOENT')
-      }).then(done)
+      }).then(done, done)
     })
 
     describe('when a custom File object is given in place of the file path', () => {

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -52,6 +52,15 @@ describe('TextBuffer IO', () => {
       })
     })
 
+    it('rejects if the given path is a directory', (done) => {
+      const dirPath = temp.mkdirSync('atom')
+      TextBuffer.load(dirPath).then(() => {
+        expect('Did not fail with EISDIR').toBeUndefined()
+      }, (err) => {
+        expect(err.code).toBe('EISDIR')
+      }).then(done, done)
+    })
+
     it('optionally rejects with an ENOENT if there is no file at the given path', (done) => {
       const filePath = 'does-not-exist.txt'
       TextBuffer.load(filePath, {mustExist: true}).then(() => {

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -8,6 +8,7 @@ const Range = require('../src/range')
 const TextBuffer = require('../src/text-buffer')
 const {TextBuffer: NativeTextBuffer} = require('superstring')
 const fsAdmin = require('fs-admin')
+const pathwatcher = require('pathwatcher')
 
 process.on('unhandledRejection', console.error)
 
@@ -16,6 +17,14 @@ describe('TextBuffer IO', () => {
 
   afterEach(() => {
     if (buffer) buffer.destroy()
+
+    const watched = pathwatcher.getWatchedPaths()
+    if (watched.length > 0) {
+      for (const watchedPath of watched) {
+        console.error(`WARNING: leaked file watcher for path ${watchedPath}`)
+      }
+      pathwatcher.closeAllWatchers()
+    }
   })
 
   describe('.load', () => {

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -60,7 +60,7 @@ describe('TextBuffer IO', () => {
       TextBuffer.load(dirPath).then(() => {
         expect('Did not fail with EISDIR').toBeUndefined()
       }, (err) => {
-        expect(err.code).toBe('EISDIR')
+        expect(err.code).toBe(process.platform === 'win32' ? 'EACCES' : 'EISDIR')
       }).then(done, done)
     })
 
@@ -109,7 +109,7 @@ describe('TextBuffer IO', () => {
         TextBuffer.loadSync(dirPath)
         expect('Did not fail with EISDIR').toBeUndefined()
       } catch (e) {
-        expect(e.code).toBe('EISDIR')
+        expect(err.code).toBe(process.platform === 'win32' ? 'EACCES' : 'EISDIR')
       }
     })
 

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -109,7 +109,7 @@ describe('TextBuffer IO', () => {
         TextBuffer.loadSync(dirPath)
         expect('Did not fail with EISDIR').toBeUndefined()
       } catch (e) {
-        expect(err.code).toBe(process.platform === 'win32' ? 'EACCES' : 'EISDIR')
+        expect(e.code).toBe(process.platform === 'win32' ? 'EACCES' : 'EISDIR')
       }
     })
 

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -103,6 +103,16 @@ describe('TextBuffer IO', () => {
       expect(buffer.getText()).toBe('')
     })
 
+    it('throws EISDIR if the path is a directory', () => {
+      const dirPath = temp.mkdirSync('atom')
+      try {
+        TextBuffer.loadSync(dirPath)
+        expect('Did not fail with EISDIR').toBeUndefined()
+      } catch (e) {
+        expect(e.code).toBe('EISDIR')
+      }
+    })
+
     it('optionally throws ENOENT if there is no file at the given path', () => {
       try {
         TextBuffer.loadSync('/does-not-exist.txt', {mustExist: true})

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -220,7 +220,11 @@ class TextBuffer
       buffer.setPath(source)
     else
       buffer.setFile(source)
-    buffer.load(clearHistory: true, internal: true, mustExist: params?.mustExist).then -> buffer
+    buffer.load(clearHistory: true, internal: true, mustExist: params?.mustExist)
+      .then -> buffer
+      .catch (err) ->
+        buffer.destroy()
+        throw err
 
   # Public: Create a new buffer backed by the given file path. For better
   # performance, use {TextBuffer.load} instead.

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -240,7 +240,11 @@ class TextBuffer
   @loadSync: (filePath, params) ->
     buffer = new TextBuffer(params)
     buffer.setPath(filePath)
-    buffer.loadSync(internal: true, mustExist: params?.mustExist)
+    try
+      buffer.loadSync(internal: true, mustExist: params?.mustExist)
+    catch e
+      buffer.destroy()
+      throw e
     buffer
 
   # Public: Restore a {TextBuffer} based on an earlier state created using


### PR DESCRIPTION
In the course of getting a clean test run for atom/atom#15681, I noticed that `TextBuffer` was leaking pathwatcher handles when `TextBuffer.load()` and `TextBuffer.loadSync()` fail in certain cases.

To catch these, I've added a leak warning to the `afterEach()` function in the test suite and patched up a bunch of other (much more innocuous) leaks in the test suite.