### PR TITLE
Fix buffer coordinate translation for soft-wrapped atomic soft tabs

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -883,46 +883,60 @@ describe('DisplayLayer', () => {
     })
 
     it('translates points correctly on soft-wrapped lines', () => {
-      const buffer = new TextBuffer({
-        text: '   abc defgh'
-      })
+      {
+        const buffer = new TextBuffer({text: '   abc defgh'})
+        const displayLayer = buffer.addDisplayLayer({
+          softWrapColumn: 8,
+          softWrapHangingIndent: 2
+        })
 
-      const displayLayer = buffer.addDisplayLayer({
-        softWrapColumn: 8,
-        softWrapHangingIndent: 2
-      })
+        expect(displayLayer.getText()).toBe('   abc \n     def\n     gh')
+        expectPositionTranslations(displayLayer, [
+          [Point(0, 0), Point(0, 0)],
+          [Point(0, 1), Point(0, 1)],
+          [Point(0, 2), Point(0, 2)],
+          [Point(0, 3), Point(0, 3)],
+          [Point(0, 4), Point(0, 4)],
+          [Point(0, 5), Point(0, 5)],
+          [Point(0, 6), Point(0, 6)],
+          [Point(0, 7), [Point(0, 6), Point(0, 7)]],
+          [Point(0, 8), [Point(0, 6), Point(0, 7)]],
+          [Point(1, 0), [Point(0, 6), Point(0, 7)]],
+          [Point(1, 1), [Point(0, 6), Point(0, 7)]],
+          [Point(1, 2), [Point(0, 6), Point(0, 7)]],
+          [Point(1, 3), [Point(0, 6), Point(0, 7)]],
+          [Point(1, 4), [Point(0, 6), Point(0, 7)]],
+          [Point(1, 5), Point(0, 7)],
+          [Point(1, 6), Point(0, 8)],
+          [Point(1, 7), Point(0, 9)],
+          [Point(1, 8), [Point(0, 9), Point(0, 10)]],
+          [Point(1, 9), [Point(0, 9), Point(0, 10)]],
+          [Point(2, 0), [Point(0, 9), Point(0, 10)]],
+          [Point(2, 1), [Point(0, 9), Point(0, 10)]],
+          [Point(2, 2), [Point(0, 9), Point(0, 10)]],
+          [Point(2, 3), [Point(0, 9), Point(0, 10)]],
+          [Point(2, 4), [Point(0, 9), Point(0, 10)]],
+          [Point(2, 5), Point(0, 10)],
+          [Point(2, 6), Point(0, 11)],
+          [Point(2, 7), Point(0, 12)]
+        ])
+      }
 
-      expect(JSON.stringify(displayLayer.getText())).toBe(JSON.stringify('   abc \n     def\n     gh'))
+      {
+        // Translating in the middle of an atomic soft tab that has been soft-wrapped.
+        const buffer = new TextBuffer({text: '    '})
+        const displayLayer = buffer.addDisplayLayer({tabLength: 2, softWrapColumn: 3})
 
-      expectPositionTranslations(displayLayer, [
-        [Point(0, 0), Point(0, 0)],
-        [Point(0, 1), Point(0, 1)],
-        [Point(0, 2), Point(0, 2)],
-        [Point(0, 3), Point(0, 3)],
-        [Point(0, 4), Point(0, 4)],
-        [Point(0, 5), Point(0, 5)],
-        [Point(0, 6), Point(0, 6)],
-        [Point(0, 7), [Point(0, 6), Point(0, 7)]],
-        [Point(0, 8), [Point(0, 6), Point(0, 7)]],
-        [Point(1, 0), [Point(0, 6), Point(0, 7)]],
-        [Point(1, 1), [Point(0, 6), Point(0, 7)]],
-        [Point(1, 2), [Point(0, 6), Point(0, 7)]],
-        [Point(1, 3), [Point(0, 6), Point(0, 7)]],
-        [Point(1, 4), [Point(0, 6), Point(0, 7)]],
-        [Point(1, 5), Point(0, 7)],
-        [Point(1, 6), Point(0, 8)],
-        [Point(1, 7), Point(0, 9)],
-        [Point(1, 8), [Point(0, 9), Point(0, 10)]],
-        [Point(1, 9), [Point(0, 9), Point(0, 10)]],
-        [Point(2, 0), [Point(0, 9), Point(0, 10)]],
-        [Point(2, 1), [Point(0, 9), Point(0, 10)]],
-        [Point(2, 2), [Point(0, 9), Point(0, 10)]],
-        [Point(2, 3), [Point(0, 9), Point(0, 10)]],
-        [Point(2, 4), [Point(0, 9), Point(0, 10)]],
-        [Point(2, 5), Point(0, 10)],
-        [Point(2, 6), Point(0, 11)],
-        [Point(2, 7), Point(0, 12)]
-      ])
+        expect(displayLayer.getText()).toBe('   \n ')
+
+        expect(displayLayer.translateBufferPosition([0, 3], {clipDirection: 'backward'})).toEqual([0, 2])
+        expect(displayLayer.translateBufferPosition([0, 3], {clipDirection: 'closest'})).toEqual([0, 2])
+        expect(displayLayer.translateBufferPosition([0, 3], {clipDirection: 'forward'})).toEqual([1, 1])
+
+        expect(displayLayer.translateScreenPosition([1, 0], {clipDirection: 'backward'})).toEqual([0, 2])
+        expect(displayLayer.translateScreenPosition([1, 0], {clipDirection: 'closest'})).toEqual([0, 2])
+        expect(displayLayer.translateScreenPosition([1, 0], {clipDirection: 'forward'})).toEqual([0, 4])
+      }
     })
 
     it('prefers the skipSoftWrapIndentation option over clipDirection when translating points', () => {

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -272,18 +272,20 @@ class DisplayLayer {
   translateBufferPosition (bufferPosition, options) {
     bufferPosition = this.buffer.clipPosition(bufferPosition)
     this.populateSpatialIndexIfNeeded(bufferPosition.row + 1, Infinity)
+
     const clipDirection = options && options.clipDirection || 'closest'
+    const columnDelta = this.getClipColumnDelta(bufferPosition, clipDirection)
+    if (columnDelta !== 0) {
+      bufferPosition = Point(bufferPosition.row, bufferPosition.column + columnDelta)
+    }
+
     let screenPosition = this.translateBufferPositionWithSpatialIndex(bufferPosition, clipDirection)
     const tabCount = this.tabCounts[screenPosition.row]
     if (tabCount > 0) {
       screenPosition = this.expandHardTabs(screenPosition, bufferPosition, tabCount)
     }
-    const columnDelta = this.getClipColumnDelta(bufferPosition, clipDirection)
-    if (columnDelta !== 0) {
-      return Point(screenPosition.row, screenPosition.column + columnDelta)
-    } else {
-      return Point.fromObject(screenPosition)
-    }
+
+    return Point.fromObject(screenPosition)
   }
 
   translateBufferPositionWithSpatialIndex (bufferPosition, clipDirection) {


### PR DESCRIPTION
Previously, when translating buffer coordinates to screen coordinates we would first use the spatial index to retrieve the corresponding screen position and then apply a delta to it in order to clip the screen column to the left or to the right of an atomic token (such as a paired unicode character or an atomic soft tab).

The problem with this approach is that applying the delta to the screen column may result in a negative screen coordinate. In particular, this could happen if the translated buffer point is in the middle of an atomic soft-tab which has been soft-wrapped exactly at the given point. Consider the example below, assuming `.`s correspond to whitespaces:

```
Buffer Text:
....

Screen Text (Tab Length: 2, Soft Wrap Column: 3):
...
.
```

In the example above, translating `(0, 3)` to screen coordinates (assuming we clip backwards) should return `(0, 2)` but, since the clip delta is expressed in buffer coordinates, we used to return `(1, -1)`.

With this pull-request we are fixing the issue by clipping the buffer position *before* translating it to screen coordinates, thus avoiding the coordinate mismatch problem described above.

An alternative solution to this could be to prevent atomic soft tabs from being soft-wrapped, exactly as we do for paired unicode characters. I was torn on going down this path because it would be a less additive change, and would also result in a change in behavior. That said, it does feel more correct so I am open to revisiting this decision.

/cc: @nathansobo @maxbrunsfeld 