### PR TITLE
Call TextBuffer.onWillChange listeners only once per transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.6.0-will-change-event-1",
+  "version": "13.6.0-will-change-event-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.5.8",
+  "version": "13.6.0-will-change-event-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.6.0-will-change-event-1",
+  "version": "13.6.0-will-change-event-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.5.8",
+  "version": "13.6.0-will-change-event-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -255,7 +255,7 @@ describe('TextBuffer IO', () => {
       expect(buffer.isModified()).toBe(true)
 
       const changeEvents = []
-      buffer.onWillChange((event) => changeEvents.push(['will-change', event]))
+      buffer.onWillChange(() => changeEvents.push(['will-change']))
       buffer.onDidChange((event) => changeEvents.push(['did-change', event]))
       buffer.onDidChangeText((event) => changeEvents.push(['did-change-text', event]))
 
@@ -877,9 +877,9 @@ describe('TextBuffer IO', () => {
 
       const events = []
       buffer.onWillReload((event) => events.push(['will-reload']))
-      buffer.onWillChange((event) => {
+      buffer.onWillChange(() => {
         expect(buffer.getText()).toEqual('abcde')
-        events.push(['will-change', event])
+        events.push(['will-change'])
       })
       buffer.onDidChange((event) => {
         expect(buffer.getText()).toEqual(newText)
@@ -909,12 +909,7 @@ describe('TextBuffer IO', () => {
             'will-reload'
           ],
           [
-            'will-change', {
-              oldRange: Range(Point(0, 0), Point(0, 5)),
-              newRange: Range(Point(0, 0), Point(0, newText.length)),
-              oldText: 'abcde',
-              newText: newText
-            }
+            'will-change'
           ],
           [
             'did-change', {
@@ -951,11 +946,11 @@ describe('TextBuffer IO', () => {
       })
     })
 
-    it('passes the smallest possible change event to onWillChange and onDidChange listeners', (done) => {
+    it('passes the smallest possible change event to onDidChange listeners', (done) => {
       fs.writeFileSync(buffer.getPath(), 'abc de ')
 
       const events = []
-      buffer.onWillChange((event) => events.push(['will-change', event]))
+      buffer.onWillChange(() => events.push(['will-change']))
       buffer.onDidChange((event) => events.push(['did-change', event]))
       buffer.onDidChangeText((event) => events.push(['did-change-text', event]))
 
@@ -966,12 +961,7 @@ describe('TextBuffer IO', () => {
 
         expect(toPlainObject(events)).toEqual(toPlainObject([
           [
-            'will-change', {
-              oldRange: Range(Point(0, 3), Point(0, 5)),
-              newRange: Range(Point(0, 3), Point(0, 7)),
-              oldText: 'de',
-              newText: ' de '
-            }
+            'will-change'
           ],
           [
             'did-change', {
@@ -1027,7 +1017,7 @@ describe('TextBuffer IO', () => {
 
     it('does not fire duplicate change events when multiple changes happen on disk', (done) => {
       const changeEvents = []
-      buffer.onWillChange((event) => changeEvents.push('will-change'))
+      buffer.onWillChange(() => changeEvents.push('will-change'))
       buffer.onDidChange((event) => changeEvents.push('did-change'))
       buffer.onDidChangeText((event) => changeEvents.push('did-change-text'))
 

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -97,16 +97,14 @@ describe "TextBuffer", ->
       expect(buffer.getText()).toEqual "hey\nyou're old\r\nhow are you doing?"
 
     describe "before a change", ->
-      it "notifies ::onWillChange observers with the relevant details", ->
-        changes = []
+      it "notifies ::onWillChange observers", ->
+        changeCount = 0
         buffer.onWillChange (change) ->
           expect(buffer.getText()).toBe "hello\nworld\r\nhow are you doing?"
-          changes.push(change)
+          changeCount++
 
         buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat", normalizeLineEndings: false)
-        expect(changes).toEqual [{
-          oldRange: [[0, 2], [2, 3]]
-        }]
+        expect(changeCount).toBe(1)
 
     describe "after a change", ->
       it "notifies, in order, decoration layers, display layers, ::onDidChange observers and display layer ::onDidChangeSync observers with the relevant details", ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2251,6 +2251,8 @@ describe "TextBuffer", ->
       expectedText = ''
 
       buffer = new TextBuffer()
+      checkpoint = buffer.createCheckpoint()
+
       buffer.onWillChange (change) ->
         expect(buffer.getText()).toBe expectedText
         changeCount++
@@ -2265,12 +2267,20 @@ describe "TextBuffer", ->
       expect(changeCount).toBe(2)
       expectedText = 'abc'
 
+      # Empty transactions do not cause onWillChange listeners to be called
+      buffer.transact ->
+      expect(changeCount).toBe(2)
+
       buffer.undo()
       expect(changeCount).toBe(3)
       expectedText = 'a'
 
       buffer.redo()
       expect(changeCount).toBe(4)
+      expectedText = 'abc'
+
+      buffer.revertToCheckpoint(checkpoint)
+      expect(changeCount).toBe(5)
 
   describe "::onDidChangeText(callback)",  ->
     beforeEach ->


### PR DESCRIPTION
In order to make multi-cursor editing truly fast, we need to get rid of all event listeners that get called on each individual buffer change. This PR changes the semantics of `TextBuffer.onWillChange` so that its listeners get called only once per transaction, before any changes. There will no longer be any argument passed.

Since this is a breaking change, I'll need to open issues on the repositories of any Atom packages that use `onWillChange`. Luckily, I think there are only 3 or 4.

/cc @nathansobo