### PR TITLE
Add DisplayLayer.destroyFoldsContainingBufferPositions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.6.0-1",
+  "version": "13.6.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.6.0-0",
+  "version": "13.6.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.5.8",
+  "version": "13.6.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.6.0-1",
+  "version": "13.6.0-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.5.8",
+  "version": "13.6.0-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.6.0-0",
+  "version": "13.6.0-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -439,11 +439,19 @@ describe('DisplayLayer', () => {
       displayLayer.foldBufferRange([[2, 2], [3, 0]])
       expect(displayLayer.getText()).toBe('a⋯j')
 
+      // Exclude endpoints
       verifyChangeEvent(displayLayer, () => {
-        displayLayer.destroyFoldsContainingBufferPositions([[1, 1], [2, 1]])
+        displayLayer.destroyFoldsContainingBufferPositions([[1, 1], [2, 1]], true)
       })
 
       expect(displayLayer.getText()).toBe('abc\ndef\ng⋯j')
+
+      // Include endpoints
+      verifyChangeEvent(displayLayer, () => {
+        displayLayer.destroyFoldsContainingBufferPositions([[2, 2]], false)
+      })
+
+      expect(displayLayer.getText()).toBe('abc\ndef\nghi\nj')
     })
 
     it('allows all folds to be destroyed', () => {

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -427,6 +427,25 @@ describe('DisplayLayer', () => {
       expect(displayLayer.getText()).toBe('abc\ndef\ngh⋯j')
     })
 
+    it('can destroy folds that contain an array of positions', () => {
+      const buffer = new TextBuffer({
+        text: 'abc\ndef\nghi\nj'
+      })
+
+      const displayLayer = buffer.addDisplayLayer()
+      displayLayer.foldBufferRange([[0, 1], [1, 2]])
+      displayLayer.foldBufferRange([[1, 1], [2, 2]])
+      displayLayer.foldBufferRange([[2, 1], [3, 0]])
+      displayLayer.foldBufferRange([[2, 2], [3, 0]])
+      expect(displayLayer.getText()).toBe('a⋯j')
+
+      verifyChangeEvent(displayLayer, () => {
+        displayLayer.destroyFoldsContainingBufferPositions([[1, 1], [2, 1]])
+      })
+
+      expect(displayLayer.getText()).toBe('abc\ndef\ng⋯j')
+    })
+
     it('allows all folds to be destroyed', () => {
       const buffer = new TextBuffer({
         text: 'abc\ndef\nghi\njkl\nmno'

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -443,14 +443,20 @@ describe('DisplayLayer', () => {
       verifyChangeEvent(displayLayer, () => {
         displayLayer.destroyFoldsContainingBufferPositions([[1, 1], [2, 1]], true)
       })
-
       expect(displayLayer.getText()).toBe('abc\ndef\ng⋯j')
 
       // Include endpoints
       verifyChangeEvent(displayLayer, () => {
         displayLayer.destroyFoldsContainingBufferPositions([[2, 2]], false)
       })
+      expect(displayLayer.getText()).toBe('abc\ndef\nghi\nj')
 
+      // Clips before checking containment
+      displayLayer.foldBufferRange([[3, 0], [3, 1]])
+      expect(displayLayer.getText()).toBe('abc\ndef\nghi\n⋯')
+      verifyChangeEvent(displayLayer, () => {
+        displayLayer.destroyFoldsContainingBufferPositions([[3, Infinity]], false)
+      })
       expect(displayLayer.getText()).toBe('abc\ndef\nghi\nj')
     })
 

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -234,6 +234,22 @@ class DisplayLayer {
     )
   }
 
+  destroyFoldsContainingBufferPositions (bufferPositions) {
+    const markersContainingPositions = new Set()
+    for (const position of bufferPositions) {
+      const foundMarkers = this.foldsMarkerLayer.findMarkers({
+        containsPosition: position
+      })
+      for (const marker of foundMarkers) {
+        if (marker.getRange().containsPoint(position, true)) {
+          markersContainingPositions.add(marker)
+        }
+      }
+    }
+    const sortedMarkers = Array.from(markersContainingPositions).sort((a, b) => a.compare(b))
+    return this.destroyFoldMarkers(sortedMarkers)
+  }
+
   destroyFoldMarkers (foldMarkers) {
     const foldedRanges = []
     if (foldMarkers.length === 0) return foldedRanges

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -234,14 +234,15 @@ class DisplayLayer {
     )
   }
 
-  destroyFoldsContainingBufferPositions (bufferPositions, excludeEndoints) {
+  destroyFoldsContainingBufferPositions (bufferPositions, excludeEndpoints) {
     const markersContainingPositions = new Set()
     for (const position of bufferPositions) {
+      const clippedPosition = this.buffer.clipPosition(position)
       const foundMarkers = this.foldsMarkerLayer.findMarkers({
-        containsPosition: position
+        containsPosition: clippedPosition
       })
       for (const marker of foundMarkers) {
-        if (!excludeEndoints || marker.getRange().containsPoint(position, true)) {
+        if (!excludeEndpoints || marker.getRange().containsPoint(clippedPosition, true)) {
           markersContainingPositions.add(marker)
         }
       }

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -234,14 +234,14 @@ class DisplayLayer {
     )
   }
 
-  destroyFoldsContainingBufferPositions (bufferPositions) {
+  destroyFoldsContainingBufferPositions (bufferPositions, excludeEndoints) {
     const markersContainingPositions = new Set()
     for (const position of bufferPositions) {
       const foundMarkers = this.foldsMarkerLayer.findMarkers({
         containsPosition: position
       })
       for (const marker of foundMarkers) {
-        if (marker.getRange().containsPoint(position, true)) {
+        if (!excludeEndoints || marker.getRange().containsPoint(position, true)) {
           markersContainingPositions.add(marker)
         }
       }


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/15565

This is a more useful method when destroying folds during selections, because it won't cause us to destroy folds that are completely contained within the selection.