### PR TITLE
Only emit one display layer change event per buffer transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.8.0-display-layer-change-event-1",
+  "version": "13.8.0-display-layer-change-event-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.7.1",
+  "version": "13.8.0-display-layer-change-event-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.7.1",
+  "version": "13.8.0-display-layer-change-event-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.8.0-display-layer-change-event-1",
+  "version": "13.8.0-display-layer-change-event-2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -1989,7 +1989,7 @@ describe('DisplayLayer', () => {
       displayLayer.setTextDecorationLayer(decorationLayer)
       const allChanges = []
 
-      displayLayer.onDidChangeSync((changes) => allChanges.push(...changes))
+      displayLayer.onDidChange((changes) => allChanges.push(...changes))
 
       decorationLayer.emitInvalidateRangeEvent([[2, 1], [3, 2]])
 
@@ -2167,7 +2167,7 @@ describe('DisplayLayer', () => {
     })
   })
 
-  describe('.onDidChangeSync', () => {
+  describe('.onDidChange', () => {
     it('calls the given callback when the display layer\'s content changes', () => {
       const buffer = new TextBuffer({
         text: 'abc\ndef\nghi\njkl\nmno'
@@ -2176,7 +2176,7 @@ describe('DisplayLayer', () => {
       const displayLayer = buffer.addDisplayLayer({tabLength: 4})
 
       const events = []
-      displayLayer.onDidChangeSync((changes) => events.push(...changes))
+      displayLayer.onDidChange((changes) => events.push(...changes))
 
       displayLayer.foldBufferRange(Range(Point(1, 1), Point(2, 2)))
       expect(events).toEqual([
@@ -2230,7 +2230,7 @@ describe('DisplayLayer', () => {
       const displayLayer = buffer.addDisplayLayer({tabLength: 4})
 
       const events = []
-      displayLayer.onDidChangeSync((changes) => events.push(changes))
+      displayLayer.onDidChange((changes) => events.push(changes))
 
       const checkpoint = buffer.createCheckpoint()
 
@@ -2594,7 +2594,7 @@ function verifyChangeEvent (displayLayer, fn) {
   displayLayerCopy.destroy()
   let changes = []
 
-  const disposable = displayLayer.onDidChangeSync((event) => {
+  const disposable = displayLayer.onDidChange((event) => {
     changes.push(...event)
   })
 

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -1994,9 +1994,8 @@ describe('DisplayLayer', () => {
       decorationLayer.emitInvalidateRangeEvent([[2, 1], [3, 2]])
 
       expect(allChanges).toEqual([{
-        start: Point(1, 0),
-        oldExtent: Point(2, 0),
-        newExtent: Point(2, 0)
+        oldRange: Range(Point(1, 0), Point(3, 0)),
+        newRange: Range(Point(1, 0), Point(3, 0))
       }])
     })
 
@@ -2181,9 +2180,8 @@ describe('DisplayLayer', () => {
       displayLayer.foldBufferRange(Range(Point(1, 1), Point(2, 2)))
       expect(events).toEqual([
         {
-          start: Point(1, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(1, 0)
+          oldRange: Range(Point(1, 0), Point(3, 0)),
+          newRange: Range(Point(1, 0), Point(2, 0))
         }
       ])
 
@@ -2191,9 +2189,8 @@ describe('DisplayLayer', () => {
       displayLayer.foldBufferRange(Range(Point(3, 1), Point(4, 2)))
       expect(events).toEqual([
         {
-          start: Point(2, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(1, 0)
+          oldRange: Range(Point(2, 0), Point(4, 0)),
+          newRange: Range(Point(2, 0), Point(3, 0))
         }
       ])
 
@@ -2201,9 +2198,8 @@ describe('DisplayLayer', () => {
       displayLayer.destroyAllFolds()
       expect(events).toEqual([
         {
-          start: Point(1, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(4, 0)
+          oldRange: Range(Point(1, 0), Point(3, 0)),
+          newRange: Range(Point(1, 0), Point(5, 0))
         }
       ])
 
@@ -2215,9 +2211,8 @@ describe('DisplayLayer', () => {
       })
       expect(events).toEqual([
         {
-          start: Point(1, 0),
-          oldExtent: Point(4, 0),
-          newExtent: Point(2, 0)
+          oldRange: Range(Point(1, 0), Point(5, 0)),
+          newRange: Range(Point(1, 0), Point(3, 0))
         }
       ])
     })
@@ -2243,14 +2238,12 @@ describe('DisplayLayer', () => {
       })
       expect(events).toEqual([[
         {
-          start: Point(0, 0),
-          oldExtent: Point(1, 0),
-          newExtent: Point(2, 0)
+          oldRange: Range(Point(0, 0), Point(1, 0)),
+          newRange: Range(Point(0, 0), Point(2, 0))
         },
         {
-          start: Point(4, 0),
-          oldExtent: Point(1, 0),
-          newExtent: Point(2, 0)
+          oldRange: Range(Point(3, 0), Point(4, 0)),
+          newRange: Range(Point(4, 0), Point(6, 0))
         }
       ]])
 
@@ -2258,14 +2251,12 @@ describe('DisplayLayer', () => {
       buffer.undo()
       expect(events).toEqual([[
         {
-          start: Point(0, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(1, 0)
+          oldRange: Range(Point(0, 0), Point(2, 0)),
+          newRange: Range(Point(0, 0), Point(1, 0))
         },
         {
-          start: Point(3, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(1, 0)
+          oldRange: Range(Point(4, 0), Point(6, 0)),
+          newRange: Range(Point(3, 0), Point(4, 0))
         }
       ]])
 
@@ -2273,14 +2264,12 @@ describe('DisplayLayer', () => {
       buffer.redo()
       expect(events).toEqual([[
         {
-          start: Point(0, 0),
-          oldExtent: Point(1, 0),
-          newExtent: Point(2, 0)
+          oldRange: Range(Point(0, 0), Point(1, 0)),
+          newRange: Range(Point(0, 0), Point(2, 0))
         },
         {
-          start: Point(4, 0),
-          oldExtent: Point(1, 0),
-          newExtent: Point(2, 0)
+          oldRange: Range(Point(3, 0), Point(4, 0)),
+          newRange: Range(Point(4, 0), Point(6, 0))
         }
       ]])
 
@@ -2288,14 +2277,12 @@ describe('DisplayLayer', () => {
       buffer.revertToCheckpoint(checkpoint)
       expect(events).toEqual([[
         {
-          start: Point(0, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(1, 0)
+          oldRange: Range(Point(0, 0), Point(2, 0)),
+          newRange: Range(Point(0, 0), Point(1, 0))
         },
         {
-          start: Point(3, 0),
-          oldExtent: Point(2, 0),
-          newExtent: Point(1, 0)
+          oldRange: Range(Point(4, 0), Point(6, 0)),
+          newRange: Range(Point(3, 0), Point(4, 0))
         }
       ]])
     })
@@ -2834,9 +2821,9 @@ function getTokenBoundaries (displayLayer, startRow = 0, endRow = displayLayer.g
 }
 
 function updateTokenLines (tokenLines, displayLayer, changes) {
-  for (const {start, oldExtent, newExtent} of changes || []) {
-    const newTokenLines = getTokens(displayLayer, start.row, start.row + newExtent.row)
-    tokenLines.splice(start.row, oldExtent.row, ...newTokenLines)
+  for (const {oldRange, newRange} of changes || []) {
+    const newTokenLines = getTokens(displayLayer, newRange.start.row, newRange.end.row)
+    tokenLines.splice(newRange.start.row, oldRange.end.row - oldRange.start.row, ...newTokenLines)
   }
 }
 

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -219,7 +219,7 @@ describe "MarkerLayer", ->
       expect(updateCount).toBe(6)
 
       # update events happen after updating display layers when there is no parent transaction.
-      displayLayer.onDidChangeSync ->
+      displayLayer.onDidChange ->
         displayLayerDidChange = true
       buffer.undo()
       expect(updateCount).toBe(7)

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -165,7 +165,7 @@ describe('TextBuffer IO', () => {
       const events = []
 
       const displayLayer = buffer.addDisplayLayer()
-      displayLayer.onDidChangeSync((event) => events.push(['display-layer', event]))
+      displayLayer.onDidChange((event) => events.push(['display-layer', event]))
 
       buffer.registerTextDecorationLayer({
         bufferDidChange ({oldRange, newRange}) { events.push(['decoration-layer', {oldRange, newRange}]) }

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -174,7 +174,7 @@ describe('TextBuffer IO', () => {
       buffer.reload().then(() => {
         expect(events).toEqual([
           ['decoration-layer', {oldRange: Range(Point(0, 7), Point(0, 7)), newRange: Range(Point(0, 7), Point(0, 11))}],
-          ['display-layer', [{start: Point(0, 0), oldExtent: Point(1, 0), newExtent: Point(1, 0)}]]
+          ['display-layer', [{oldRange: Range(Point(0, 0), Point(1, 0)), newRange: Range(Point(0, 0), Point(1, 0))}]]
         ])
         done()
       })

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -97,7 +97,7 @@ describe "TextBuffer", ->
       expect(buffer.getText()).toEqual "hey\nyou're old\r\nhow are you doing?"
 
     describe "after a change", ->
-      it "notifies, in order, decoration layers, display layers, and display layer ::onDidChangeSync observers with the relevant details", ->
+      it "notifies, in order, decoration layers, display layers, and display layer ::onDidChange observers with the relevant details", ->
         buffer = new TextBuffer("hello\nworld\r\nhow are you doing?")
 
         events = []
@@ -120,7 +120,7 @@ describe "TextBuffer", ->
         buffer.registerTextDecorationLayer(textDecorationLayer1) # insert a duplicate decoration layer
         buffer.registerTextDecorationLayer(textDecorationLayer2)
         buffer.onDidChange (e) -> events.push({source: 'buffer', event: JSON.parse(JSON.stringify(e))})
-        displayLayer1.onDidChangeSync (e) -> events.push({source: 'display-layer-event', event: e})
+        displayLayer1.onDidChange (e) -> events.push({source: 'display-layer-event', event: e})
 
         buffer.transact ->
           buffer.setTextInRange([[0, 2], [2, 3]], "y there\r\ncat\nwhat", normalizeLineEndings: false)

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -163,9 +163,8 @@ describe "TextBuffer", ->
           {
             source: 'display-layer-event',
             event: [{
-              start: Point(0, 0),
-              oldExtent: Point(3, 0),
-              newExtent: Point(3, 0)
+              oldRange: Range(Point(0, 0), Point(3, 0)),
+              newRange: Range(Point(0, 0), Point(3, 0))
             }]
           }
         ]

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -154,7 +154,7 @@ class DisplayLayer {
         const endRow = this.translateBufferPositionWithSpatialIndex(Point(endBufferRow, 0), 'backward').row
         const extent = Point(endRow - startRow, 0)
         spliceArray(this.cachedScreenLines, startRow, extent.row, new Array(extent.row))
-        this.emitDidChangeSyncEvent([{
+        this.emitChangeEvent([{
           start: Point(startRow, 0),
           oldExtent: extent,
           newExtent: extent
@@ -186,8 +186,8 @@ class DisplayLayer {
     this.displayMarkerLayersById.delete(id)
   }
 
-  onDidChangeSync (callback) {
-    return this.emitter.on('did-change-sync', callback)
+  onDidChange (callback) {
+    return this.emitter.on('did-change', callback)
   }
 
   onDidReset (callback) {
@@ -208,7 +208,7 @@ class DisplayLayer {
     if (containingFoldMarkers.length === 0) {
       const foldStartRow = bufferRange.start.row
       const foldEndRow = bufferRange.end.row + 1
-      this.emitDidChangeSyncEvent([
+      this.emitChangeEvent([
         this.updateSpatialIndex(foldStartRow, foldEndRow, foldEndRow, Infinity)
       ])
       this.notifyObserversIfMarkerScreenPositionsChanged()
@@ -270,7 +270,7 @@ class DisplayLayer {
       foldMarker.destroy()
     }
 
-    this.emitDidChangeSyncEvent([this.updateSpatialIndex(
+    this.emitChangeEvent([this.updateSpatialIndex(
       combinedRangeStart.row,
       combinedRangeEnd.row + 1,
       combinedRangeEnd.row + 1,
@@ -825,7 +825,7 @@ class DisplayLayer {
       combinedChanges.splice(Point(startRow, 0), extent, extent)
     }
 
-    this.emitDidChangeSyncEvent(combinedChanges.getChanges().map((hunk) => {
+    this.emitChangeEvent(combinedChanges.getChanges().map((hunk) => {
       return {
         start: Point.fromObject(hunk.newStart),
         oldExtent: traversal(hunk.oldEnd, hunk.oldStart),
@@ -834,9 +834,9 @@ class DisplayLayer {
     }))
   }
 
-  emitDidChangeSyncEvent (event) {
+  emitChangeEvent (event) {
     if (this.buffer.transactCallDepth === 0) {
-      this.emitter.emit('did-change-sync', event)
+      this.emitter.emit('did-change', event)
     } else {
       for (const change of event) {
         this.deferredChangeEventPatch.splice(change.start, change.oldExtent, change.newExtent)
@@ -846,7 +846,7 @@ class DisplayLayer {
 
   emitDeferredChangeEvents () {
     if (this.deferredChangeEventPatch.getChangeCount() > 0) {
-      this.emitter.emit('did-change-sync', this.deferredChangeEventPatch.getChanges().map((change) => ({
+      this.emitter.emit('did-change', this.deferredChangeEventPatch.getChanges().map((change) => ({
         start: change.newStart,
         oldExtent: traversal(change.oldEnd, change.oldStart),
         newExtent: traversal(change.newEnd, change.newStart)

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -825,7 +825,7 @@ class DisplayLayer {
       combinedChanges.splice(Point(startRow, 0), extent, extent)
     }
 
-    return Object.freeze(combinedChanges.getChanges().map((hunk) => {
+    this.emitDidChangeSyncEvent(combinedChanges.getChanges().map((hunk) => {
       return {
         start: Point.fromObject(hunk.newStart),
         oldExtent: traversal(hunk.oldEnd, hunk.oldStart),

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1906,15 +1906,19 @@ class TextBuffer
       @_emittedWillChangeEvent = true
 
   emitDidChangeTextEvent: ->
-    if @transactCallDepth is 0 and @changesSinceLastDidChangeTextEvent.length > 0
-      compactedChanges = Object.freeze(normalizePatchChanges(
-        patchFromChanges(@changesSinceLastDidChangeTextEvent).getChanges()
-      ))
-      @changesSinceLastDidChangeTextEvent.length = 0
-      if compactedChanges.length > 0
-        @emitter.emit 'did-change-text', new ChangeEvent(this, compactedChanges)
-      @debouncedEmitDidStopChangingEvent()
-      @_emittedWillChangeEvent = false
+    if @transactCallDepth is 0
+      if @changesSinceLastDidChangeTextEvent.length > 0
+        compactedChanges = Object.freeze(normalizePatchChanges(
+          patchFromChanges(@changesSinceLastDidChangeTextEvent).getChanges()
+        ))
+        @changesSinceLastDidChangeTextEvent.length = 0
+        if compactedChanges.length > 0
+          @emitter.emit 'did-change-text', new ChangeEvent(this, compactedChanges)
+        @debouncedEmitDidStopChangingEvent()
+        @_emittedWillChangeEvent = false
+      for id, displayLayer of @displayLayers
+        displayLayer.emitDeferredChangeEvents()
+    return
 
   # Identifies if the buffer belongs to multiple editors.
   #

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -369,9 +369,6 @@ class TextBuffer
   # Public: This is now identical to {onDidChange}.
   onDidChangeText: (callback) -> @onDidChange(callback)
 
-  preemptDidChange: (callback) ->
-    @emitter.preempt 'did-change', callback
-
   # Public: Invoke the given callback asynchronously following one or more
   # changes after {::getStoppedChangingDelay} milliseconds elapse without an
   # additional change.

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1126,7 +1126,11 @@ class TextBuffer
   undo: ->
     if pop = @historyProvider.undo()
       @emitWillChangeEvent()
-      @applyChange(change) for change in pop.textUpdates
+      @transactCallDepth++
+      try
+        @applyChange(change) for change in pop.textUpdates
+      finally
+        @transactCallDepth--
       @restoreFromMarkerSnapshot(pop.markers)
       @emitDidChangeTextEvent()
       @emitMarkerChangeEvents(pop.markers)
@@ -1138,7 +1142,11 @@ class TextBuffer
   redo: ->
     if pop = @historyProvider.redo()
       @emitWillChangeEvent()
-      @applyChange(change) for change in pop.textUpdates
+      @transactCallDepth++
+      try
+        @applyChange(change) for change in pop.textUpdates
+      finally
+        @transactCallDepth--
       @restoreFromMarkerSnapshot(pop.markers)
       @emitDidChangeTextEvent()
       @emitMarkerChangeEvents(pop.markers)
@@ -1210,7 +1218,11 @@ class TextBuffer
   revertToCheckpoint: (checkpoint, options) ->
     if truncated = @historyProvider.revertToCheckpoint(checkpoint, options)
       @emitWillChangeEvent()
-      @applyChange(change) for change in truncated.textUpdates
+      @transactCallDepth++
+      try
+        @applyChange(change) for change in truncated.textUpdates
+      finally
+        @transactCallDepth--
       @restoreFromMarkerSnapshot(truncated.markers)
       @emitDidChangeTextEvent()
       @emitter.emit 'did-update-markers'

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -881,16 +881,9 @@ class TextBuffer
     # Emit the change event on all the registered text decoration layers.
     @textDecorationLayers.forEach (textDecorationLayer) ->
       textDecorationLayer.bufferDidChange(changeEvent)
-    # Emit the change event on all the registered display layers.
-    changeEventsByDisplayLayer = new Map()
     for id, displayLayer of @displayLayers
       event = displayLayer.bufferDidChange(changeEvent)
-      changeEventsByDisplayLayer.set(displayLayer, event)
-    # Emit a normal `did-change` event for other subscribers too.
-    @emitter.emit 'did-change', changeEvent
-    # Emit a `did-change-sync` event from all the registered display layers.
-    changeEventsByDisplayLayer.forEach (event, displayLayer) ->
-      displayLayer.emitDidChangeSyncEvent(event)
+    return
 
   # Public: Delete the text in the given range.
   #


### PR DESCRIPTION
Similar to #270, #273

Previously, `DisplayLayers` would call their `onDidChangeSync` callbacks once each time their underlying `TextBuffer` changed. This was a source of slowness when typing with multiple cursors and prevented us from wanting to implement features like auto-indent in terms of a series of small buffer changes.

In this PR, I've renamed `.onDidChangeSync` to `.onDidChange` and changed it so that callbacks are only called one time per text buffer transaction. I have also changed the events that it emits so that instead of having `start`, `oldExtent` and `newExtent` properties, they have `oldRange` and `newRange` properties similar to `TextBuffer.onDidChange` events.

/cc @nathansobo 