### PR TITLE
Fix the behavior of the `undo: 'skip'` option

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -200,7 +200,7 @@ describe "TextBuffer", ->
         expect(buffer.lineForRow(0)).toBe "yellow"
 
         expect(buffer.undo()).toBe true
-        expect(buffer.lineForRow(0)).toBe "hellow"
+        expect(buffer.lineForRow(0)).toBe "hello"
 
       it "still emits marker change events (regression)", ->
         markerLayer = buffer.addMarkerLayer()
@@ -2398,7 +2398,7 @@ describe "TextBuffer", ->
       buffer.transact ->
         buffer.insert([1, 0], "v")
         buffer.insert([1, 1], "x")
-        buffer.setTextInRange([[1, 2], [1, 2]], "y", {undo: 'skip'})
+        buffer.insert([1, 2], "y")
         buffer.insert([2, 3], "zw")
         buffer.delete([[2, 3], [2, 4]])
 
@@ -2421,9 +2421,9 @@ describe "TextBuffer", ->
       buffer.undo()
       assertChangesEqual(textChanges, [
         {
-          oldRange: [[1, 0], [1, 2]],
+          oldRange: [[1, 0], [1, 3]],
           newRange: [[1, 0], [1, 0]],
-          oldText: "vx",
+          oldText: "vxy",
           newText: "",
         },
         {
@@ -2439,9 +2439,9 @@ describe "TextBuffer", ->
       assertChangesEqual(textChanges, [
         {
           oldRange: [[1, 0], [1, 0]],
-          newRange: [[1, 0], [1, 2]],
+          newRange: [[1, 0], [1, 3]],
           oldText: "",
-          newText: "vx",
+          newText: "vxy",
         },
         {
           oldRange: [[2, 3], [2, 3]],
@@ -2498,7 +2498,7 @@ describe "TextBuffer", ->
           buffer.transact ->
             buffer.insert([0, 0], 'b')
             buffer.insert([1, 0], 'c')
-            buffer.setTextInRange([[1, 1], [1, 1]], 'd', {undo: 'skip'})
+            buffer.insert([1, 1], 'd')
         expect(didStopChangingCallback).not.toHaveBeenCalled()
 
         wait delay / 2, ->
@@ -2534,9 +2534,9 @@ describe "TextBuffer", ->
                   newText: "",
                 },
                 {
-                  oldRange: [[1, 0], [1, 1]],
+                  oldRange: [[1, 0], [1, 2]],
                   newRange: [[1, 0], [1, 0]],
-                  oldText: "c",
+                  oldText: "cd",
                   newText: "",
                 },
               ])

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1231,6 +1231,9 @@ class TextBuffer
   groupChangesSinceCheckpoint: (checkpoint) ->
     @historyProvider.groupChangesSinceCheckpoint(checkpoint, {markers: @createMarkerSnapshot(), deleteCheckpoint: false})
 
+  groupLastChanges: ->
+    @historyProvider.groupLastChanges()
+
   # Public: Returns a list of changes since the given checkpoint.
   #
   # If the given checkpoint is no longer present in the undo history, this

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1232,6 +1232,12 @@ class TextBuffer
   groupChangesSinceCheckpoint: (checkpoint) ->
     @historyProvider.groupChangesSinceCheckpoint(checkpoint, {markers: @createMarkerSnapshot(), deleteCheckpoint: false})
 
+  # Public: Group the last two text changes for purposes of undo/redo.
+  #
+  # This operation will only succeed if there are two changes on the undo
+  # stack. It will not group past the beginning of an open transaction.
+  #
+  # Returns a {Boolean} indicating whether the operation succeeded.
   groupLastChanges: ->
     @historyProvider.groupLastChanges()
 


### PR DESCRIPTION
This PR changes the behavior of undo after calling `.setTextInRange` with the `{undo: 'skip'}` option. Previously, the change would not be added to the undo stack, but this led to an inconsistent state.

Now, when undoing after calling `.setTextInRange` with `{undo: 'skip'}`, the change is undone along with the preceding change. Hopefully, this matches the intent of package authors using this option.

We've updated the documentation to discourage using `{undo: 'skip'}` and instead to call the new method `.groupLastChanges` after making the change.

Fixes https://github.com/atom/atom/issues/15827

🍐 'd with @nathansobo