### PR TITLE
Fix handling of legacy serialization format

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -251,7 +251,8 @@ class TextBuffer
       promise = @load(params.filePath, params).then (buffer) ->
         # TODO - Remove this once Atom 1.19 stable has been out for a while.
         if typeof params.text is 'string'
-          buffer.setText(params.text)
+          if params.digestWhenLastPersisted is buffer.file?.getDigestSync?()
+            buffer.setText(params.text)
 
         else if buffer.digestWhenLastPersisted is params.digestWhenLastPersisted
           buffer.buffer.deserializeChanges(params.outstandingChanges)


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/16081

This fixes a bug in the handling of old serialized state. It was introduced in https://github.com/atom/text-buffer/pull/225. Previously, when using the old serialization format, we would unconditionally set the buffer's text to the serialized text, even if the file had changed on disk since the state was serialized 😱 .