### PR TITLE
Preserve marker identity when resurrecting a marker after undo/redo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.11.0-0",
+  "version": "13.11.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,9 +634,9 @@
       }
     },
     "electron": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.12.tgz",
-      "integrity": "sha512-JncFnznbIOr73sKOaIb80twVW0gmf13h3LECYQPHlZ9RHWve1/Yw6NPqTapprfMJn81ipVxQqLw45fFF3LnrFQ==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.10.tgz",
+      "integrity": "sha1-Oj6D2WX9f6/kc76N349HJWG2JT0=",
       "dev": true,
       "requires": {
         "@types/node": "7.0.42",
@@ -3117,10 +3117,11 @@
       }
     },
     "pathwatcher": {
-      "version": "https://registry.npmjs.org/pathwatcher/-/pathwatcher-8.0.1.tgz",
-      "integrity": "sha1-UaLOKgHbbDLYZ/ZYXvKEvmvQo64=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pathwatcher/-/pathwatcher-8.0.1.tgz",
+      "integrity": "sha512-NN+P7PRWdT8Zd1FwGOX/eLFD8tNuFBdDW/ysL5ufi9BFqAgOfQrV0pMMY/oRDFOZEUR4Y8RudXpLuPjE9b2pmQ==",
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+        "async": "0.2.10",
         "emissary": "1.3.3",
         "event-kit": "2.4.0",
         "fs-plus": "3.0.1",
@@ -3131,7 +3132,8 @@
       },
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.10.1",
+  "version": "13.11.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.10.1",
+  "version": "13.11.0-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.11.0-0",
+  "version": "13.11.0-1",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coffee-script": "^1.10.0",
     "coffeelint": "1.16.0",
     "dedent": "^0.6.0",
-    "electron": "1.6",
+    "electron": "1.7",
     "grunt": "^0.4.5",
     "grunt-atomdoc": "^1.0.1",
     "grunt-cli": "^0.1.13",

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -117,11 +117,13 @@ describe "MarkerLayer", ->
       buffer.undo()
 
       expect(buffer.getText()).toBe 'foo'
+      expect(marker1.isDestroyed()).toBe false
       markers = layer3.findMarkers({})
       expect(markers.length).toBe 2
-      expect(markers[0].getProperties()).toEqual {c: 'd'}
+      expect(markers[0]).toBe marker1
+      expect(markers[0].getProperties()).toEqual {a: 'b'}
       expect(markers[0].getRange()).toEqual [[0, 0], [0, 0]]
-      expect(markers[1].getProperties()).toEqual {a: 'b'}
+      expect(markers[1].getProperties()).toEqual {c: 'd'}
       expect(markers[1].getRange()).toEqual [[0, 0], [0, 0]]
       expect(marker2ChangeCount).toBe(2)
 

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -114,10 +114,13 @@ describe "MarkerLayer", ->
         marker4 = layer3.markRange([[1, 0], [1, 3]], g: 'h', invalidate: 'never')
         expect(marker2ChangeCount).toBe(1)
 
+      createdMarker = null
+      layer3.onDidCreateMarker((m) => createdMarker = m)
       buffer.undo()
 
       expect(buffer.getText()).toBe 'foo'
       expect(marker1.isDestroyed()).toBe false
+      expect(createdMarker).toBe(marker1)
       markers = layer3.findMarkers({})
       expect(markers.length).toBe 2
       expect(markers[0]).toBe marker1

--- a/src/default-history-provider.coffee
+++ b/src/default-history-provider.coffee
@@ -385,13 +385,19 @@ class DefaultHistoryProvider
         else
           throw new Error("Unexpected undoStack entry type during deserialization: #{entry.type}")
 
-  serializeSnapshot: (snapshot, options) ->
+  serializeSnapshot: (layerSnapshot, options) ->
     return unless options.markerLayers
 
-    layers = {}
-    for id, snapshot of snapshot when @buffer.getMarkerLayer(id)?.persistent
-      layers[id] = snapshot
-    layers
+    serializedLayerSnapshots = {}
+    for layerId, layerSnapshot of layerSnapshot
+      continue unless @buffer.getMarkerLayer(layerId)?.persistent
+      serializedMarkerSnapshots = {}
+      for markerId, markerSnapshot of layerSnapshot
+        serializedMarkerSnapshot = Object.assign({}, markerSnapshot)
+        delete serializedMarkerSnapshot.marker
+        serializedMarkerSnapshots[markerId] = serializedMarkerSnapshot
+      serializedLayerSnapshots[layerId] = serializedMarkerSnapshots
+    serializedLayerSnapshots
 
 snapshotFromCheckpoint = (checkpoint) ->
   {

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -290,7 +290,14 @@ class MarkerLayer
       if marker = @markersById[id]
         marker.update(marker.getRange(), snapshot, true, true)
       else
-        newMarker = @createMarker(snapshot.range, snapshot, true)
+        {marker} = snapshot
+        if marker
+          @markersById[marker.id] = marker
+          {range} = snapshot
+          @index.insert(marker.id, range.start, range.end)
+          marker.update(marker.getRange(), snapshot, true, true)
+        else
+          newMarker = @createMarker(snapshot.range, snapshot, true)
 
     for id in existingMarkerIds
       if (marker = @markersById[id]) and (not snapshots[id]?)
@@ -301,7 +308,7 @@ class MarkerLayer
     ranges = @index.dump()
     for id in Object.keys(@markersById)
       marker = @markersById[id]
-      result[id] = marker.getSnapshot(Range.fromObject(ranges[id]), false)
+      result[id] = marker.getSnapshot(Range.fromObject(ranges[id]))
     result
 
   emitChangeEvents: (snapshot) ->
@@ -314,7 +321,9 @@ class MarkerLayer
     markersById = {}
     for id in Object.keys(@markersById)
       marker = @markersById[id]
-      markersById[id] = marker.getSnapshot(Range.fromObject(ranges[id]), false)
+      snapshot = marker.getSnapshot(Range.fromObject(ranges[id]), false)
+      markersById[id] = snapshot
+
     {@id, @maintainHistory, @persistent, markersById, version: SerializationVersion}
 
   deserialize: (state) ->

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -296,6 +296,7 @@ class MarkerLayer
           {range} = snapshot
           @index.insert(marker.id, range.start, range.end)
           marker.update(marker.getRange(), snapshot, true, true)
+          @emitter.emit 'did-create-marker', marker if @emitCreateMarkerEvents
         else
           newMarker = @createMarker(snapshot.range, snapshot, true)
 

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -280,7 +280,7 @@ class Marker
   #
   # * `params` {Object}
   copy: (options={}) ->
-    snapshot = @getSnapshot(null)
+    snapshot = @getSnapshot()
     options = Marker.extractParams(options)
     @layer.createMarker(@getRange(), extend(
       {}
@@ -382,8 +382,10 @@ class Marker
     @layer.markerUpdated() if updated and not suppressMarkerLayerUpdateEvents
     updated
 
-  getSnapshot: (range) ->
-    Object.freeze({range, @properties, @reversed, @tailed, @valid, @invalidate, @exclusive})
+  getSnapshot: (range, includeMarker=true) ->
+    snapshot = {range, @properties, @reversed, @tailed, @valid, @invalidate, @exclusive}
+    snapshot.marker = this if includeMarker
+    Object.freeze(snapshot)
 
   toString: ->
     "[Marker #{@id}, #{@getRange()}]"


### PR DESCRIPTION
MarkerLayers can be created with a maintainHistory option, which allows the state of the marker layer to be restored to the state it had at the start/end of a transaction when undoing/redoing.

During this restoration process, a marker can be "resurrected". This can happen when you undo the transaction in which a marker was created and then redo it. Or it can happen when you undo a transaction in which a marker was destroyed.

Currently, when restoring a snapshot containing a marker that no longer exists, we create a *new* marker that mostly matches the state of the marker in the snapshot. However, this new marker does not have the same *id* as the previous marker. Also, even though markers are tracked in the index via their identifiers, we return markers as first-class objects in our API. Currently, because we create a new marker when resurrecting, anyone holding a reference to the old marker still sees their reference as destroyed. They're hanging on to stale state.

This PR changes our marker layer snapshots to include a reference to the marker object along with the snapshot of the marker's state. When restoring a marker that doesn't exist, we recycle the original object so that holders of existing references see their marker come back to life. This will allow snippets that don't contain mirrored tab stops to work correctly after undoing and redoing the snippet expansion, and just leads to a more coherent API overall.

It's worth noting that when *serializing* marker snapshots, we obviously can't include the object reference. This PR has conditional logic when serializing to ensure we don't include the marker reference in that situation, and we preserve the original behavior when restoring marker layer snapshots that don't include references, which happens during deserialization.

This PR also updates the Electron dependency used for interactive test runner to match the current Atom.

/cc @ungb 
  