### PR TITLE
Fix clipping when translating a screen position inside of a hard tab

### DIFF
--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -2131,6 +2131,23 @@ describe('DisplayLayer', () => {
         clipDirection: 'forward'
       })).toEqual([0, 8])
     })
+
+    it('clips to the closest tab stop when translating a screen position that is in the middle of a hard tab', () => {
+      const buffer = new TextBuffer({text: '\t\t\t'})
+      const displayLayer = buffer.addDisplayLayer({tabLength: 4})
+
+      expect(displayLayer.translateScreenPosition([0, 0])).toEqual([0, 0])
+      expect(displayLayer.translateScreenPosition([0, 1])).toEqual([0, 0])
+      expect(displayLayer.translateScreenPosition([0, 2])).toEqual([0, 0])
+      expect(displayLayer.translateScreenPosition([0, 3])).toEqual([0, 1])
+      expect(displayLayer.translateScreenPosition([0, 4])).toEqual([0, 1])
+
+      expect(displayLayer.translateScreenPosition([0, 8])).toEqual([0, 2])
+      expect(displayLayer.translateScreenPosition([0, 9])).toEqual([0, 2])
+      expect(displayLayer.translateScreenPosition([0, 10])).toEqual([0, 2])
+      expect(displayLayer.translateScreenPosition([0, 11])).toEqual([0, 3])
+      expect(displayLayer.translateScreenPosition([0, 12])).toEqual([0, 3])
+    })
   })
 
   describe('.getApproximateScreenLineCount()', () => {

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -507,10 +507,10 @@ class DisplayLayer {
           } else if (clipDirection === 'forward') {
             return Point(targetScreenPosition.row, unexpandedScreenColumn + 1)
           } else {
-            if (targetScreenPosition.column - expandedScreenColumn > nextTabStopColumn - targetScreenPosition.column) {
-              return Point(targetScreenPosition.row, unexpandedScreenColumn)
-            } else {
+            if (targetScreenPosition.column > Math.ceil((nextTabStopColumn + expandedScreenColumn) / 2)) {
               return Point(targetScreenPosition.row, unexpandedScreenColumn + 1)
+            } else {
+              return Point(targetScreenPosition.row, unexpandedScreenColumn)
             }
           }
         }


### PR DESCRIPTION
Previously, there was a logic error in `DisplayLayer.collapseHardTabs` that was causing that function to not honor the `clipDirection: closest` parameter when the provided screen position was located inside of a hard tab.

This pull request fixes that logic error by clipping to the next tab stop only if the given screen position is past the midpoint of the expanded hard tab.

/cc: @nathansobo 