### PR TITLE
Provide old language mode from onDidChangeLanguageMode

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2611,7 +2611,7 @@ describe "TextBuffer", ->
       expect(buffer.getLanguageMode() instanceof NullLanguageMode).toBe(true)
 
       events = []
-      buffer.onDidChangeLanguageMode (event) -> events.push(event)
+      buffer.onDidChangeLanguageMode (newMode, oldMode) -> events.push({newMode: newMode, oldMode: oldMode})
 
       languageMode = {
         onDidChangeHighlighting: -> {dispose: ->}
@@ -2620,12 +2620,14 @@ describe "TextBuffer", ->
       buffer.setLanguageMode(languageMode)
       expect(buffer.getLanguageMode()).toBe(languageMode)
       expect(events.length).toBe(1)
-      expect(events[0]).toBe(languageMode)
+      expect(events[0].newMode).toBe(languageMode)
+      expect(events[0].oldMode instanceof NullLanguageMode).toBe(true)
 
       buffer.setLanguageMode(null)
       expect(buffer.getLanguageMode() instanceof NullLanguageMode).toBe(true)
       expect(events.length).toBe(2)
-      expect(events[1]).toBe(buffer.getLanguageMode())
+      expect(events[1].newMode).toBe(buffer.getLanguageMode())
+      expect(events[1].oldMode).toBe(languageMode)
 
   describe "line ending support", ->
     beforeEach ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1747,11 +1747,12 @@ class TextBuffer
   #        that begin at the current position.
   setLanguageMode: (languageMode) ->
     if languageMode isnt @languageMode
+      oldLanguageMode = @languageMode
       @languageMode.destroy?()
       @languageMode = languageMode or new NullLanguageMode()
       for id, displayLayer of @displayLayers
         displayLayer.bufferDidChangeLanguageMode(languageMode)
-      @emitter.emit('did-change-language-mode', @languageMode)
+      @emitter.emit('did-change-language-mode', {newMode: @languageMode, oldMode: oldLanguageMode})
     return
 
   # Experimental: Call the given callback whenever the buffer's language mode changes.
@@ -1759,10 +1760,12 @@ class TextBuffer
   # * `callback` - A {Function} to call when the language mode changes.
   #   * `languageMode` - The buffer's new language mode {Object}. See {TextBuffer::setLanguageMode}
   #     for its interface.
+  #   * `oldlanguageMode` - The buffer's old language mode {Object}. See {TextBuffer::setLanguageMode}
+  #     for its interface.
   #
   # Returns a {Disposable} that can be used to stop the callback from being called.
   onDidChangeLanguageMode: (callback) ->
-    @emitter.on('did-change-language-mode', callback)
+    @emitter.on('did-change-language-mode', ({newMode, oldMode}) -> callback(newMode, oldMode))
 
   ###
   Section: Private Utility Methods


### PR DESCRIPTION
This change adds a second parameter to callbacks that are registered with `onDidChangeLanguageMode`.  This second parameter contains the buffer's previous language mode before the new mode was set.

This PR is related to atom/atom#13829 which reports that when saving an untitled file, the `softWrapped` setting that they changed using the "Toggle Soft Wrap" command gets reset once the file is saved.  A corresponding PR will be sent to atom/atom shortly.