### PR TITLE
Add exceptional snapshot handling for selectionsMarkerLayer

### DIFF
--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -281,12 +281,13 @@ describe "MarkerLayer", ->
 
   describe "::copy", ->
     it "creates a new marker layer with markers in the same states", ->
-      originalLayer = buffer.addMarkerLayer(maintainHistory: true)
+      originalLayer = buffer.addMarkerLayer(maintainHistory: true, role: "role1")
       originalLayer.markRange([[0, 1], [0, 3]], a: 'b')
       originalLayer.markPosition([0, 2])
 
       copy = originalLayer.copy()
       expect(copy).not.toBe originalLayer
+      expect(copy.getRole()).toBe("role1")
 
       markers = copy.getMarkers()
       expect(markers.length).toBe 2

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -172,9 +172,24 @@ describe "MarkerLayer", ->
 
   describe "when role is provided for the layer", ->
     it "getRole() returns it's role", ->
-      expect(buffer.addMarkerLayer(role: "role1").getRole()).toBe("role1")
-      expect(buffer.addMarkerLayer(role: "role2").getRole()).toBe("role2")
-      expect(buffer.addMarkerLayer().getRole()).toBe(undefined)
+      expect(Object.keys(buffer.markerLayerIdsByRole).length).toBe(0)
+
+      layerRoleA1 = buffer.addMarkerLayer(role: "role-a")
+      layerRoleB1 = buffer.addMarkerLayer(role: "role-b")
+      layerNoRole = buffer.addMarkerLayer()
+      expect(layerRoleA1.getRole()).toBe("role-a")
+      expect(layerRoleB1.getRole()).toBe("role-b")
+      expect(layerNoRole.getRole()).toBe(undefined)
+
+      expect(buffer.markerLayerIdsByRole["role-a"].has(layerRoleA1.id)).toBe(true)
+      expect(buffer.markerLayerIdsByRole["role-a"].size).toBe(1)
+      expect(buffer.markerLayerIdsByRole["role-b"].has(layerRoleB1.id)).toBe(true)
+      expect(buffer.markerLayerIdsByRole["role-b"].size).toBe(1)
+
+      layerRoleA2 = buffer.addMarkerLayer(role: "role-a")
+      expect(buffer.markerLayerIdsByRole["role-a"].has(layerRoleA1.id)).toBe(true)
+      expect(buffer.markerLayerIdsByRole["role-a"].has(layerRoleA2.id)).toBe(true)
+      expect(buffer.markerLayerIdsByRole["role-a"].size).toBe(2)
 
   describe "::findMarkers(params)", ->
     it "does not find markers from other layers", ->

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -303,6 +303,9 @@ describe "MarkerLayer", ->
       copy = originalLayer.copy()
       expect(copy).not.toBe originalLayer
       expect(copy.getRole()).toBe("role1")
+      expect(buffer.markerLayerIdsByRole["role1"].has(originalLayer.id)).toBe(true)
+      expect(buffer.markerLayerIdsByRole["role1"].has(copy.id)).toBe(true)
+      expect(buffer.markerLayerIdsByRole["role1"].size).toBe(2)
 
       markers = copy.getMarkers()
       expect(markers.length).toBe 2

--- a/spec/marker-layer-spec.coffee
+++ b/spec/marker-layer-spec.coffee
@@ -170,6 +170,12 @@ describe "MarkerLayer", ->
       # Should not throw an exception
       buffer.undo()
 
+  describe "when role is provided for the layer", ->
+    it "getRole() returns it's role", ->
+      expect(buffer.addMarkerLayer(role: "role1").getRole()).toBe("role1")
+      expect(buffer.addMarkerLayer(role: "role2").getRole()).toBe("role2")
+      expect(buffer.addMarkerLayer().getRole()).toBe(undefined)
+
   describe "::findMarkers(params)", ->
     it "does not find markers from other layers", ->
       defaultMarker = buffer.markRange([[0, 3], [0, 6]])

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1441,6 +1441,9 @@ describe "TextBuffer", ->
         expect(bufferB.getText()).toBe "hellooo there\ngood friend\r\nhow are you doing??"
         expectSameMarkers(bufferB.getMarkerLayer(layerA.id), layerA)
         expect(bufferB.getMarkerLayer(layerA.id).getRole()).toBe "role1"
+        expect(Object.keys(bufferB.markerLayerIdsByRole)).toEqual(["role1"])
+        expect(bufferB.markerLayerIdsByRole["role1"].size).toBe(1)
+        expect(bufferB.markerLayerIdsByRole["role1"].has(layerA.id)).toBe(true)
         expect(bufferB.getMarkerLayer(layerA.id).maintainHistory).toBe true
         expect(bufferB.getMarkerLayer(layerA.id).persistent).toBe true
 

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -697,7 +697,7 @@ describe "TextBuffer", ->
       expect(getFirstMarker(markerLayers[1])).toBe(marker1)
       expect(getFirstMarker(markerLayers[2])).toBe(marker2)
 
-    describe "role based snapshotting of createCheckpoint, groupChangesSinceCheckpoint", ->
+    describe "role based snapshotting on createCheckpoint, groupChangesSinceCheckpoint", ->
       it "skip snapshotting of other marker layers with the same role of activeMarkerLayer", ->
         eventHandler = jasmine.createSpy('eventHandler')
 

--- a/src/default-history-provider.coffee
+++ b/src/default-history-provider.coffee
@@ -385,11 +385,11 @@ class DefaultHistoryProvider
         else
           throw new Error("Unexpected undoStack entry type during deserialization: #{entry.type}")
 
-  serializeSnapshot: (layerSnapshot, options) ->
+  serializeSnapshot: (snapshot, options) ->
     return unless options.markerLayers
 
     serializedLayerSnapshots = {}
-    for layerId, layerSnapshot of layerSnapshot
+    for layerId, layerSnapshot of snapshot
       continue unless @buffer.getMarkerLayer(layerId)?.persistent
       serializedMarkerSnapshots = {}
       for markerId, markerSnapshot of layerSnapshot

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -35,6 +35,7 @@ class MarkerLayer
     @maintainHistory = options?.maintainHistory ? false
     @destroyInvalidatedMarkers = options?.destroyInvalidatedMarkers ? false
     @role = options?.role
+    @delegate.addRoleId(@role, @id) if @role?
     @persistent = options?.persistent ? false
     @emitter = new Emitter
     @index = new MarkerIndex
@@ -343,6 +344,7 @@ class MarkerLayer
     @id = state.id
     @maintainHistory = state.maintainHistory
     @role = state.role
+    @delegate.addRoleId(@role, @id) if @role?
     @persistent = state.persistent
     for id, markerState of state.markersById
       range = Range.fromObject(markerState.range)

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -35,7 +35,7 @@ class MarkerLayer
     @maintainHistory = options?.maintainHistory ? false
     @destroyInvalidatedMarkers = options?.destroyInvalidatedMarkers ? false
     @role = options?.role
-    @delegate.addRoleId(@role, @id) if @role?
+    @delegate.registerRoleForMarkerLayer(@role, this) if @role?
     @persistent = options?.persistent ? false
     @emitter = new Emitter
     @index = new MarkerIndex
@@ -344,7 +344,7 @@ class MarkerLayer
     @id = state.id
     @maintainHistory = state.maintainHistory
     @role = state.role
-    @delegate.addRoleId(@role, @id) if @role?
+    @delegate.registerRoleForMarkerLayer(@role, this) if @role?
     @persistent = state.persistent
     for id, markerState of state.markersById
       range = Range.fromObject(markerState.range)

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -35,7 +35,7 @@ class MarkerLayer
     @maintainHistory = options?.maintainHistory ? false
     @destroyInvalidatedMarkers = options?.destroyInvalidatedMarkers ? false
     @role = options?.role
-    @delegate.registerRoleForMarkerLayer(@role, this) if @role?
+    @delegate.registerSelectionsMarkerLayer(this) if @role is "selections"
     @persistent = options?.persistent ? false
     @emitter = new Emitter
     @index = new MarkerIndex
@@ -344,7 +344,7 @@ class MarkerLayer
     @id = state.id
     @maintainHistory = state.maintainHistory
     @role = state.role
-    @delegate.registerRoleForMarkerLayer(@role, this) if @role?
+    @delegate.registerSelectionsMarkerLayer(this) if @role is "selections"
     @persistent = state.persistent
     for id, markerState of state.markersById
       range = Range.fromObject(markerState.range)

--- a/src/marker-layer.coffee
+++ b/src/marker-layer.coffee
@@ -48,7 +48,7 @@ class MarkerLayer
   # Public: Create a copy of this layer with markers in the same state and
   # locations.
   copy: ->
-    copy = @delegate.addMarkerLayer({@maintainHistory})
+    copy = @delegate.addMarkerLayer({@maintainHistory, @role})
     for markerId, marker of @markersById
       snapshot = marker.getSnapshot(null)
       copy.createMarker(marker.getRange(), marker.getSnapshot())

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -961,9 +961,6 @@ class TextBuffer
   addMarkerLayer: (options) ->
     layer = new MarkerLayer(this, String(@nextMarkerLayerId++), options)
     @markerLayers[layer.id] = layer
-    if layer.role
-      @markerLayerIdsByRole[layer.role] ?= new Set()
-      @markerLayerIdsByRole[layer.role].add(layer.id)
     layer
 
   # Public: Get a {MarkerLayer} by id.
@@ -1844,6 +1841,9 @@ class TextBuffer
   ###
   Section: Private Utility Methods
   ###
+  addRoleId: (role, markerLayerId) ->
+    @markerLayerIdsByRole[role] ?= new Set()
+    @markerLayerIdsByRole[role].add(markerLayerId)
 
   loadSync: (options) ->
     unless options?.internal

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -2034,19 +2034,15 @@ class TextBuffer
     snapshot
 
   restoreFromMarkerSnapshot: (snapshot, selectionsMarkerLayer) ->
-    console.log 'restore', selectionsMarkerLayer
-
     if selectionsMarkerLayer?
-      # When snapshot includes multiple layerSnapshot of `role`, disable snapshot restore target redirection
-      # to avoid multiple layerSnapshots being restored to single markerLayer.
+      # Do selective selections marker restoration only when snapshot includes single selections snapshot.
       selectionsSnapshotIds = Object.keys(snapshot).filter (id) => @selectionsMarkerLayerIds.has(id)
       if selectionsSnapshotIds.length is 1
         selectionsSnapshotId = selectionsSnapshotIds[0]
-        alwaysCreate = selectionsSnapshotId isnt selectionsMarkerLayer.id
 
     for markerLayerId, layerSnapshot of snapshot
-      if selectionsMarkerLayer? and markerLayerId is selectionsSnapshotId
-        @markerLayers[selectionsMarkerLayer.id].restoreFromSnapshot(layerSnapshot, alwaysCreate)
+      if markerLayerId is selectionsSnapshotId
+        @markerLayers[selectionsMarkerLayer.id].restoreFromSnapshot(layerSnapshot, markerLayerId isnt selectionsMarkerLayer.id)
       else
         @markerLayers[markerLayerId]?.restoreFromSnapshot(layerSnapshot)
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -1841,9 +1841,9 @@ class TextBuffer
   ###
   Section: Private Utility Methods
   ###
-  addRoleId: (role, markerLayerId) ->
+  registerRoleForMarkerLayer: (role, markerLayer) ->
     @markerLayerIdsByRole[role] ?= new Set()
-    @markerLayerIdsByRole[role].add(markerLayerId)
+    @markerLayerIdsByRole[role].add(markerLayer.id)
 
   loadSync: (options) ->
     unless options?.internal

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -954,6 +954,7 @@ class TextBuffer
   #     of the buffer. Defaults to `false`. If `true`, the marker layer's id
   #     will be maintained across the serialization boundary, allowing you to
   #     retrieve it via {::getMarkerLayer}.
+  #   * `role` (optional) A {String} indicating role of this marker layer
   #
   # Returns a {MarkerLayer}.
   addMarkerLayer: (options) ->
@@ -1118,8 +1119,13 @@ class TextBuffer
 
   # Public: Undo the last operation. If a transaction is in progress, aborts it.
   #
+  # * `options` (optional) {Object}
+  #   * `activeMarkerLayer` (optional)
+  #     Marker layer's snapshot with the same role as given activeMarkerLayer
+  #     is restored to activeMarkerLayer
+  #
   # Returns a {Boolean} of whether or not a change was made.
-  undo: ->
+  undo: (options) ->
     if pop = @historyProvider.undo()
       @emitWillChangeEvent()
       @transactCallDepth++
@@ -1127,7 +1133,7 @@ class TextBuffer
         @applyChange(change) for change in pop.textUpdates
       finally
         @transactCallDepth--
-      @restoreFromMarkerSnapshot(pop.markers)
+      @restoreFromMarkerSnapshot(pop.markers, options?.activeMarkerLayer)
       @emitDidChangeTextEvent()
       @emitMarkerChangeEvents(pop.markers)
       true
@@ -1136,8 +1142,13 @@ class TextBuffer
 
   # Public: Redo the last operation
   #
+  # * `options` (optional) {Object}
+  #   * `activeMarkerLayer` (optional)
+  #     Marker layer's snapshot with the same role as given activeMarkerLayer
+  #     is restored to activeMarkerLayer
+  #
   # Returns a {Boolean} of whether or not a change was made.
-  redo: ->
+  redo: (options) ->
     if pop = @historyProvider.redo()
       @emitWillChangeEvent()
       @transactCallDepth++
@@ -1145,7 +1156,7 @@ class TextBuffer
         @applyChange(change) for change in pop.textUpdates
       finally
         @transactCallDepth--
-      @restoreFromMarkerSnapshot(pop.markers)
+      @restoreFromMarkerSnapshot(pop.markers, options?.activeMarkerLayer)
       @emitDidChangeTextEvent()
       @emitMarkerChangeEvents(pop.markers)
       true
@@ -1159,18 +1170,31 @@ class TextBuffer
   # abort the transaction, call {::abortTransaction} to terminate the function's
   # execution and revert any changes performed up to the abortion.
   #
+  # * `options` (optional) {Object}
+  #   * `groupingInterval` (optional) The {Number} of milliseconds for which this
+  #     transaction should be considered 'open for grouping' after it begins. If
+  #     a transaction with a positive `groupingInterval` is committed while the
+  #     previous transaction is still open for grouping, the two transactions
+  #     are merged with respect to undo and redo.
+  #   * `activeMarkerLayer` (optional)
+  #     When provided, skip taking snapshot for other markerLayers of the same role.
   # * `groupingInterval` (optional) The {Number} of milliseconds for which this
   #   transaction should be considered 'open for grouping' after it begins. If a
   #   transaction with a positive `groupingInterval` is committed while the previous
   #   transaction is still open for grouping, the two transactions are merged with
   #   respect to undo and redo.
   # * `fn` A {Function} to call inside the transaction.
-  transact: (groupingInterval, fn) ->
-    if typeof groupingInterval is 'function'
-      fn = groupingInterval
+  transact: (options, fn) ->
+    if typeof options is 'function'
+      fn = options
       groupingInterval = 0
+    else if typeof options is 'object'
+      {groupingInterval, activeMarkerLayer} = options
+      groupingInterval ?= 0
+    else
+      groupingInterval = options
 
-    checkpointBefore = @historyProvider.createCheckpoint(markers: @createMarkerSnapshot(), isBarrier: true)
+    checkpointBefore = @historyProvider.createCheckpoint(markers: @createMarkerSnapshot(activeMarkerLayer), isBarrier: true)
 
     try
       @transactCallDepth++
@@ -1183,7 +1207,7 @@ class TextBuffer
       @transactCallDepth--
 
     return result if @isDestroyed()
-    endMarkerSnapshot = @createMarkerSnapshot()
+    endMarkerSnapshot = @createMarkerSnapshot(activeMarkerLayer)
     @historyProvider.groupChangesSinceCheckpoint(checkpointBefore, {markers: endMarkerSnapshot, deleteCheckpoint: true})
     @historyProvider.applyGroupingInterval(groupingInterval)
     @historyProvider.enforceUndoStackSizeLimit()
@@ -1203,9 +1227,13 @@ class TextBuffer
   # Public: Create a pointer to the current state of the buffer for use
   # with {::revertToCheckpoint} and {::groupChangesSinceCheckpoint}.
   #
+  # * `options` (optional) {Object}
+  #   * `activeMarkerLayer` (optional)
+  #     When provided, skip taking snapshot for other markerLayers of the same role.
+  #
   # Returns a checkpoint id value.
-  createCheckpoint: ->
-    @historyProvider.createCheckpoint(markers: @createMarkerSnapshot(), isBarrier: false)
+  createCheckpoint: (options) ->
+    @historyProvider.createCheckpoint(markers: @createMarkerSnapshot(options?.activeMarkerLayer), isBarrier: false)
 
   # Public: Revert the buffer to the state it was in when the given
   # checkpoint was created.
@@ -1216,9 +1244,13 @@ class TextBuffer
   # return `false`.
   #
   # * `checkpoint` {Number} id of the checkpoint to revert to.
+  # * `options` (optional) {Object}
+  #   * `activeMarkerLayer` (optional)
+  #     Marker layer's snapshot with the same role as given activeMarkerLayer
+  #     is restored to activeMarkerLayer
   #
   # Returns a {Boolean} indicating whether the operation succeeded.
-  revertToCheckpoint: (checkpoint) ->
+  revertToCheckpoint: (checkpoint, options) ->
     if truncated = @historyProvider.revertToCheckpoint(checkpoint)
       @emitWillChangeEvent()
       @transactCallDepth++
@@ -1226,7 +1258,7 @@ class TextBuffer
         @applyChange(change) for change in truncated.textUpdates
       finally
         @transactCallDepth--
-      @restoreFromMarkerSnapshot(truncated.markers)
+      @restoreFromMarkerSnapshot(truncated.markers, options?.activeMarkerLayer)
       @emitDidChangeTextEvent()
       @emitter.emit 'did-update-markers'
       @emitMarkerChangeEvents(truncated.markers)
@@ -1241,10 +1273,13 @@ class TextBuffer
   # grouping will be performed and this method will return `false`.
   #
   # * `checkpoint` {Number} id of the checkpoint to group changes since.
+  # * `options` (optional) {Object}
+  #   * `activeMarkerLayer` (optional)
+  #     When provided, skip taking snapshot for other markerLayers of the same role.
   #
   # Returns a {Boolean} indicating whether the operation succeeded.
-  groupChangesSinceCheckpoint: (checkpoint) ->
-    @historyProvider.groupChangesSinceCheckpoint(checkpoint, {markers: @createMarkerSnapshot(), deleteCheckpoint: false})
+  groupChangesSinceCheckpoint: (checkpoint, options) ->
+    @historyProvider.groupChangesSinceCheckpoint(checkpoint, {markers: @createMarkerSnapshot(options?.activeMarkerLayer), deleteCheckpoint: false})
 
   # Public: Group the last two text changes for purposes of undo/redo.
   #
@@ -1989,16 +2024,32 @@ class TextBuffer
       @fileSubscriptions.add @file.onWillThrowWatchError (error) =>
         @emitter.emit 'will-throw-watch-error', error
 
-  createMarkerSnapshot: ->
+  createMarkerSnapshot: (activeMarkerLayer) ->
     snapshot = {}
-    for markerLayerId, markerLayer of @markerLayers
-      if markerLayer.maintainHistory
-        snapshot[markerLayerId] = markerLayer.createSnapshot()
+
+    role = activeMarkerLayer?.getRole()
+
+    for markerLayerId, markerLayer of @markerLayers when markerLayer.maintainHistory
+      if role? and (markerLayer.getRole() is role) and (markerLayer isnt activeMarkerLayer)
+        continue
+      snapshot[markerLayerId] = markerLayer.createSnapshot()
     snapshot
 
-  restoreFromMarkerSnapshot: (snapshot) ->
-    for markerLayerId, layerSnapshot of snapshot
-      @markerLayers[markerLayerId]?.restoreFromSnapshot(layerSnapshot)
+  restoreFromMarkerSnapshot: (snapshot, activeMarkerLayer) ->
+    role = activeMarkerLayer?.getRole()
+    if role?
+      # When snapshot includes multiple layerSnapshot of same `role`, disable snapshot restore target redirection
+      # to avoid multiple layerSnapshot being restored to single markerLayer, its just confusing.
+      layerSnapshotsOfSameRole = Object.keys(snapshot).filter (markerLayerId) =>
+        @markerLayers[markerLayerId].getRole() is role
+      if layerSnapshotsOfSameRole.length isnt 1
+        role = null
+
+    for markerLayerId, layerSnapshot of snapshot when markerLayer = @markerLayers[markerLayerId]
+      if role? and markerLayer.getRole() is role
+        activeMarkerLayer.restoreFromSnapshot(layerSnapshot, activeMarkerLayer isnt markerLayer)
+      else
+        markerLayer.restoreFromSnapshot(layerSnapshot)
 
   emitMarkerChangeEvents: (snapshot) ->
     if @transactCallDepth is 0


### PR DESCRIPTION
Aiming to fix atom/atom#16176

### Scenario Which I want to fix(or improve)

When undo/redo, editor does not scroll to textual changes if editor is different editor from editor on which original change was made.
This situation easily happens when we opened multiple text-editors which shares same buffer.

### Condition

- Open `editor1`, make **change-1**
- Open `editor2` by copying `editor1`, make **change-2**
- Open `editor3` by copying `editor2`, make **change-3**
- Now `editor1`, `editor2`, `editor3` shares same buffer instance and have distinct selectionsMarkerLayer which is used to keep distinct cursors

# Current behavior

- Undo on `editor1`, `editor1`'s cursor is not restored to **point-of-before-change-3**.
- Undo on `editor2`, `editor2`'s cursor is restored to **point-of-before-change-2**, since `editor2` is same editor where **change-2** was made.
- Undo on `editor3`, `editor3`'s cursor is not restored to **point-of-before-change-1**.
- Open `editor4` by copying `editor3` and then destroy `editor1`, `editor2`, `editor3`
- Undoing/Redoing on `editor4` only undo/redo textual changes, but cursor is not restored, and not scrolled to textual changes, because `selectionsMarkerLayer` is not shared across editors.

# New behavior

NOTE: Require changes' in atom's text-editor to use new machanism

- Undo on `editor1`, `editor1`'s cursor is restored to **point-of-before-change-3** by restoring marker snapshot taken on `editor3`'s selectionsMarkerLayer to `editor1`.
- Undo on `editor2`, `editor2`'s cursor is restored to **point-of-before-change-2**.
- Undo on `editor3`, `editor3`'s cursor is restored to **point-of-before-change-1**.
- Open `editor4` by copying `editor3` and then destroy `editor1`, `editor2`, `editor3`
- Undoing/Redoing on `editor4` does undo/redo textual changes, and cursor is restored to each snapshot-ed point when change was made, because when undo/redo `selectionsMarkerLayer` is restored from different `selectionsMarkerLayer` which shares same buffer.

## Summary of changes

- buffer instance keep `selectionsMarkerLayerIds` as `Set`, it must be registered explicitly
- `transact`/`createCheckpoint`/`groupChangesSinceCheckpoint` take `selectionsMarkerLayerId`
  - Which eventually passed to `createMarkerSnapshot()` and skips snapshoting other `selectionsMarkerLayer` except passed id's.
  - Purpose of this skipping is to not restore cursor(=selections) which is not involved in changes
  - This skipping assure that snapshot does not contains multiple selectionsMarkerLayer's snapshot.
- `undo`/`redo` accept `selectionsMarkerLayerId`
  - Which restore snapshot taken in different `selectionsMarkerLayer` onto passed `selectionsMarkerLayerId`.
  - It’s like redirect restore target from originally taken layer to different layer
