### PR TITLE
Add emitDidChangePath as helper method for teletype bug 147

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3864,9 +3864,9 @@
       }
     },
     "superstring": {
-      "version": "2.2.13",
-      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.2.13.tgz",
-      "integrity": "sha512-nizh7J3/wMzXAO1LLwad/GzyWK6ELf56UkLbmcCJmtd6aS0ml2lcPKbULPS5xZDp8p9Gk5nVGQKQUrftgGs5+A==",
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.2.17.tgz",
+      "integrity": "sha512-7/3jvvetxkJvVpoJwtA+30aha/COezEppfjESOAJvXMDtCY2UkDdgB5B7ltCr0KnCqMhhXOdSsI+ahgfqLfJ0Q==",
       "requires": {
         "nan": "2.6.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3864,9 +3864,9 @@
       }
     },
     "superstring": {
-      "version": "2.2.17",
-      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.2.17.tgz",
-      "integrity": "sha512-7/3jvvetxkJvVpoJwtA+30aha/COezEppfjESOAJvXMDtCY2UkDdgB5B7ltCr0KnCqMhhXOdSsI+ahgfqLfJ0Q==",
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.2.13.tgz",
+      "integrity": "sha512-nizh7J3/wMzXAO1LLwad/GzyWK6ELf56UkLbmcCJmtd6aS0ml2lcPKbULPS5xZDp8p9Gk5nVGQKQUrftgGs5+A==",
       "requires": {
         "nan": "2.6.2"
       }

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1341,35 +1341,6 @@ describe "TextBuffer", ->
           expect(buffer2.getPath()).toBeUndefined()
           expect(buffer2.getText()).toBe("abc")
 
-  describe "::emitDidChangePath()", ->
-    beforeEach ->
-      buffer = new TextBuffer("this\nis a test\r\ntesting")
-
-    afterEach ->
-      buffer.destroy()
-
-    it "does not reset a path that is null", ->
-      didChangePathCallback = jasmine.createSpy()
-      buffer.onDidChangePath(didChangePathCallback)
-      buffer.emitDidChangePath()
-      expect(didChangePathCallback).toHaveBeenCalledWith(undefined)
-      expect(buffer.getPath()).toBe(undefined)
-
-    it "does not change the path of a saved file", ->
-      didChangePathCallback = jasmine.createSpy()
-      buffer.onDidChangePath(didChangePathCallback)
-      tempDir = fs.realpathSync(temp.mkdirSync('text-buffer'))
-      filePath = join(tempDir, "new_file")
-      fs.writeFileSync(filePath, "")
-      buffer.setPath(filePath)
-      didChangePathCallback.calls.reset()
-      buffer.emitDidChangePath()
-
-      expect(didChangePathCallback).toHaveBeenCalledWith(filePath)
-      expect(buffer.getPath()).toBe(filePath)
-
-      fs.removeSync(filePath)
-
   describe "::getRange()", ->
     it "returns the range of the entire buffer text", ->
       buffer = new TextBuffer("abc\ndef\nghi")

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1341,6 +1341,35 @@ describe "TextBuffer", ->
           expect(buffer2.getPath()).toBeUndefined()
           expect(buffer2.getText()).toBe("abc")
 
+  describe "::emitDidChangePath()", ->
+    beforeEach ->
+      buffer = new TextBuffer("this\nis a test\r\ntesting")
+
+    afterEach ->
+      buffer.destroy()
+
+    it "does not reset a path that is null", ->
+      didChangePathCallback = jasmine.createSpy()
+      buffer.onDidChangePath(didChangePathCallback)
+      buffer.emitDidChangePath()
+      expect(didChangePathCallback).toHaveBeenCalledWith(undefined)
+      expect(buffer.getPath()).toBe(undefined)
+
+    it "does not change the path of a saved file", ->
+      didChangePathCallback = jasmine.createSpy()
+      buffer.onDidChangePath(didChangePathCallback)
+      tempDir = fs.realpathSync(temp.mkdirSync('text-buffer'))
+      filePath = join(tempDir, "new_file")
+      fs.writeFileSync(filePath, "")
+      buffer.setPath(filePath)
+      didChangePathCallback.calls.reset()
+      buffer.emitDidChangePath()
+
+      expect(didChangePathCallback).toHaveBeenCalledWith(filePath)
+      expect(buffer.getPath()).toBe(filePath)
+
+      fs.removeSync(filePath)
+
   describe "::getRange()", ->
     it "returns the range of the entire buffer text", ->
       buffer = new TextBuffer("abc\ndef\nghi")

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -1372,6 +1372,31 @@ describe "TextBuffer", ->
         expect(buffer.rangeForRow(-1)).toEqual([[0, 0], [0, 4]])
         expect(buffer.rangeForRow(10)).toEqual([[2, 0], [2, 7]])
 
+    describe "::emitDidChangePath()", ->
+      beforeEach ->
+        buffer = new TextBuffer("this\nis a test\r\ntesting")
+      afterEach ->
+        buffer.destroy()
+      it "does not reset a path that is null", ->
+        didChangePathCallback = jasmine.createSpy()
+        buffer.onDidChangePath(didChangePathCallback)
+        buffer.emitDidChangePath()
+        expect(didChangePathCallback).toHaveBeenCalledWith(undefined)
+        expect(buffer.getPath()).toBe(undefined)
+
+      it "does not change the path of a saved file", ->
+        didChangePathCallback = jasmine.createSpy()
+        buffer.onDidChangePath(didChangePathCallback)
+        tempDir = fs.realpathSync(temp.mkdirSync('text-buffer'))
+        filePath = join(tempDir, "new_file")
+        fs.writeFileSync(filePath, "")
+        buffer.setPath(filePath)
+        didChangePathCallback.calls.reset()
+        buffer.emitDidChangePath()
+        expect(didChangePathCallback).toHaveBeenCalledWith(filePath)
+        expect(buffer.getPath()).toBe(filePath)
+        fs.removeSync(filePath)
+
   describe "::onDidChangePath()", ->
     [filePath, newPath, bufferToChange, eventHandler] = []
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -570,9 +570,6 @@ class TextBuffer
     return if filePath is @getPath()
     @setFile(new File(filePath) if filePath)
 
-  emitDidChangePath: ->
-    @emitter.emit 'did-change-path', @getPath()
-
   # Experimental: Set a custom {File} object as the buffer's backing store.
   #
   # * `file` An {Object} with the following properties:

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -570,6 +570,9 @@ class TextBuffer
     return if filePath is @getPath()
     @setFile(new File(filePath) if filePath)
 
+  emitDidChangePath: ->
+    @emitter.emit 'did-change-path', @getPath()
+
   # Experimental: Set a custom {File} object as the buffer's backing store.
   #
   # * `file` An {Object} with the following properties:


### PR DESCRIPTION
**Requirements**

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
All new code requires tests to ensure against regressions

**Description of the Change**
In a teletype Issue, [147](https://github.com/atom/teletype/issues/147), the guest's tab names (paths) are not reflecting the host's names when the host changes their path (i.e., `Save as...`). To remedy this, when the path changes, we need to access the Guest's `Text-Buffer` and have the buffer emit a `path-did-change` message. Since there is no actual file on the guest's filesystem for this, the `setPath` function does not work.  @lee-dohm recommended that we add a helper function (so that _Teletype_ does not access the _TextBuffer_ emitter directly).
We are adding the helper function `emitDidChangePath` (no parameters) to call this emitter.
This PR is a precursor to two future PRs in teletype and teletype-client.

**Alternate Designs**
We considered accessing the _TextBuffer_'s emitter directly through `this.buffer.emitter.emit('did-change-path', null)`, but realized that this is dangerous to do, since if _Text-Buffer_'s code is refactored, then _Teletype_ may have issues.

**Why Should This Be In Core?**
Adding this functionality is a prerequisite for a solution to a bug in Teletype, which is a key package, to be fixed properly. In particular this incorporates regression tests to ensure that the solution will hold up to code refactoring.

**Benefits**
[147](https://github.com/atom/teletype/issues/147) will be able to be resolved.

**Possible Drawbacks**
We have not yet noticed any drawbacks to this change, as it is simply adding and a function and not modifying existing code.

**Verification Process**
We have locally tested that the new function properly emits the correct message to have all TextEditors update their titles.
We have added two tests to the `text-buffer-spec.coffee` file and ensured that they work, using `atom --test.
`
**Applicable Issues**
[147](https://github.com/atom/teletype/issues/147)