### PR TITLE
Doc change for setFile (existsSync is necessary)

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -576,6 +576,7 @@ class TextBuffer
   #   * `getPath` A {Function} that returns the {String} path to the file.
   #   * `createReadStream` A {Function} that returns a `Readable` stream
   #     that can be used to load the file's content.
+  #   * `existsSync` A {function} that returns the {Boolean}, true if the file exists, false otherwise
   #   * `createWriteStream` A {Function} that returns a `Writable` stream
   #     that can be used to save content to the file.
   #   * `onDidChange` (optional) A {Function} that invokes its callback argument

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -578,7 +578,7 @@ class TextBuffer
   #     that can be used to load the file's content.
   #   * `createWriteStream` A {Function} that returns a `Writable` stream
   #     that can be used to save content to the file.
-  #   * `existsSync` A {function} that returns the {Boolean}, true if the file exists, false otherwise
+  #   * `existsSync` A {Function} that returns a {Boolean}, true if the file exists, false otherwise.
   #   * `onDidChange` (optional) A {Function} that invokes its callback argument
   #     when the file changes. The method should return a {Disposable} that
   #     can be used to prevent further calls to the callback.

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -576,9 +576,9 @@ class TextBuffer
   #   * `getPath` A {Function} that returns the {String} path to the file.
   #   * `createReadStream` A {Function} that returns a `Readable` stream
   #     that can be used to load the file's content.
-  #   * `existsSync` A {function} that returns the {Boolean}, true if the file exists, false otherwise
   #   * `createWriteStream` A {Function} that returns a `Writable` stream
   #     that can be used to save content to the file.
+  #   * `existsSync` A {function} that returns the {Boolean}, true if the file exists, false otherwise
   #   * `onDidChange` (optional) A {Function} that invokes its callback argument
   #     when the file changes. The method should return a {Disposable} that
   #     can be used to prevent further calls to the callback.


### PR DESCRIPTION
existsSync method is necessary for the object passed into setFile. Should be reflected in comment atom/text-buffer/issues/258