### PR TITLE
TextBuffer::hasAstral()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3864,9 +3864,9 @@
       }
     },
     "superstring": {
-      "version": "2.2.19",
-      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.2.19.tgz",
-      "integrity": "sha512-8OeCq44sbBGbU5ZlspMSfqk8teDXW0PvaiTbdLEXtjz3sxLeELVRq8w0llOW7pi3he3cOfoI5yAxk4NgCvlNGQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.3.0.tgz",
+      "integrity": "sha512-CXCa27o/WluULYrJEDGixZi9RTZ7orsNCoQTYfXD/Cdhs7EVNI2rJe/+Im8Cq8lyYzhCX8CFyeda3wPCSMn/oQ==",
       "requires": {
         "nan": "2.6.2"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mkdirp": "^0.5.1",
     "pathwatcher": "8.0.1",
     "serializable": "^1.0.3",
-    "superstring": "^2.2.20",
+    "superstring": "2.3.0",
     "underscore-plus": "^1.0.0"
   },
   "standard": {

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -2609,6 +2609,13 @@ describe "TextBuffer", ->
       buffer.setText('\n')
       expect(buffer.isEmpty()).toBeFalsy()
 
+  describe "::hasAstral()", ->
+    it "returns true for buffers containing surrogate pairs", ->
+      expect(new TextBuffer('hooray 😄').hasAstral()).toBeTruthy()
+
+    it "returns false for buffers that do not contain surrogate pairs", ->
+      expect(new TextBuffer('nope').hasAstral()).toBeFalsy()
+
   describe "::onWillChange(callback)", ->
     it "notifies observers before a transaction, an undo or a redo", ->
       changeCount = 0

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -728,6 +728,12 @@ class TextBuffer
         return row unless @isRowBlank(row)
     null
 
+  # Extended: Return true if the buffer contains any astral-plane Unicode characters that
+  # are encoded as surrogate pairs.
+  #
+  # Returns a {Boolean}.
+  hasAstral: -> @buffer.hasAstral()
+
   ###
   Section: Mutating Text
   ###

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -170,6 +170,7 @@ class TextBuffer
     @nextMarkerId = 1
     @outstandingSaveCount = 0
     @loadCount = 0
+    @cachedHasAstral = null
     @_emittedWillChangeEvent = false
 
     @setEncoding(params?.encoding)
@@ -732,7 +733,12 @@ class TextBuffer
   # are encoded as surrogate pairs.
   #
   # Returns a {Boolean}.
-  hasAstral: -> @buffer.hasAstral()
+  hasAstral: ->
+    if @cachedHasAstral isnt null
+      @cachedHasAstral
+    else
+      @cachedHasAstral = @buffer.hasAstral()
+      @cachedHasAstral
 
   ###
   Section: Mutating Text
@@ -2072,6 +2078,7 @@ class TextBuffer
       @_emittedWillChangeEvent = true
 
   emitDidChangeTextEvent: ->
+    @cachedHasAstral = null
     if @transactCallDepth is 0
       if @changesSinceLastDidChangeTextEvent.length > 0
         compactedChanges = patchFromChanges(@changesSinceLastDidChangeTextEvent).getChanges()


### PR DESCRIPTION
Expose `TextBuffer::hasAstral()` from atom/superstring#62. It's O(n) on the buffer size, so cache the result, invalidating it any time we're about to emit an `onDidChange()` event.