### PR TITLE
Clarify deprecation of `undo: skip` option

### DIFF
--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -843,7 +843,9 @@ class TextBuffer
   # * `text` A {String} representing the text to insert.
   # * `options` (optional) {Object}
   #   * `normalizeLineEndings` (optional) {Boolean} (default: true)
-  #   * `undo` (optional) {String} 'skip' will skip the undo system
+  #   * `undo` (optional) *Deprecated* {String} 'skip' will skip the undo
+  #     system. This property is deprecated. Call groupLastChanges() on the
+  #     {TextBuffer} afterward instead.
   #
   # Returns the {Range} of the inserted text.
   insert: (position, text, options) ->
@@ -854,7 +856,9 @@ class TextBuffer
   # * `text` A {String} representing the text text to append.
   # * `options` (optional) {Object}
   #   * `normalizeLineEndings` (optional) {Boolean} (default: true)
-  #   * `undo` (optional) {String} 'skip' will skip the undo system
+  #   * `undo` (optional) *Deprecated* {String} 'skip' will skip the undo
+  #     system. This property is deprecated. Call groupLastChanges() on the
+  #     {TextBuffer} afterward instead.
   #
   # Returns the {Range} of the inserted text
   append: (text, options) ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -810,6 +810,8 @@ class TextBuffer
   setTextInRange: (range, newText, options) ->
     if options?
       {normalizeLineEndings, undo} = options
+      Grim.deprecate('The `undo` option is deprecated. Call groupLastChanges() on the TextBuffer afterward instead.') if undo?
+
     normalizeLineEndings ?= true
 
     if @transactCallDepth is 0


### PR DESCRIPTION
https://github.com/atom/text-buffer/pull/282 updated the docs for `TextBuffer::setTextInRange` to deprecate the `undo` option. https://github.com/atom/atom/issues/16956 points out that there are other public methods whose docs reference the `undo` option. This pull request updates the docs for those other methods so that they also identify the `undo` option as deprecated. It also emits a deprecation warning whenever the `undo` option is used.
