### PR TITLE
Avoid unnecessary decoration iterator seek call

### DIFF
--- a/src/screen-line-builder.js
+++ b/src/screen-line-builder.js
@@ -79,7 +79,7 @@ class ScreenLineBuilder {
       this.inLeadingWhitespace = true
       this.inTrailingWhitespace = false
 
-      if (!didSeekDecorationIterator || this.compareBufferPosition(decorationIterator.getPosition())) {
+      if (!didSeekDecorationIterator || this.compareBufferPosition(decorationIterator.getPosition()) > 0) {
         didSeekDecorationIterator = true
         this.scopeIdsToReopen = decorationIterator.seek(Point(this.bufferRow, this.bufferColumn))
       }

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -114,6 +114,7 @@ class TextBuffer
   @Point: Point
   @Range: Range
   @newlineRegex: newlineRegex
+  @spliceArray: spliceArray
 
   encoding: null
   stoppedChangingDelay: 300


### PR DESCRIPTION
We were unnecessarily calling `seek` at the end of every buffer line, which was cheap in the case of the [`TextMateLanguageMode`](https://github.com/atom/atom/blob/master/src/text-mate-language-mode.js) but more expensive for the [`TreeSitterLanguageMode`](https://github.com/atom/atom/blob/master/src/tree-sitter-language-mode.js) in the case where there were a lot of injections.

I also made the `spliceArray` method accessible as a `TextBuffer` property, since that's a useful utility.

/cc @queerviolet 