### PR TITLE
Pass end buffer row to decoration iterator's seek method

### DIFF
--- a/spec/helpers/test-language-mode.js
+++ b/spec/helpers/test-language-mode.js
@@ -110,15 +110,16 @@ class TestHighlightIterator {
     this.layer = layer
   }
 
-  seek (position) {
+  seek (position, endBufferRow) {
     const {containingStart, boundaries} = this.layer.markerIndex.findBoundariesAfter(position, Number.MAX_SAFE_INTEGER)
     this.boundaries = boundaries
     this.boundaryIndex = 0
+    this.endBufferRow = endBufferRow
     return containingStart
   }
 
   moveToSuccessor () {
-    return this.boundaryIndex++
+    this.boundaryIndex++
   }
 
   getPosition () {
@@ -130,6 +131,7 @@ class TestHighlightIterator {
     const result = []
     const boundary = this.boundaries[this.boundaryIndex]
     if (boundary) {
+      expect(boundary.position.row).not.toBeGreaterThan(this.endBufferRow)
       boundary.ending.forEach((markerId) => {
         if (!boundary.starting.has(markerId)) {
           result.push(markerId)
@@ -143,6 +145,7 @@ class TestHighlightIterator {
     const result = []
     const boundary = this.boundaries[this.boundaryIndex]
     if (boundary) {
+      expect(boundary.position.row).not.toBeGreaterThan(this.endBufferRow)
       boundary.starting.forEach((markerId) => {
         if (!boundary.ending.has(markerId)) {
           result.push(markerId)

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -1103,7 +1103,7 @@ class DisplayLayer {
     while (true) {
       let bufferPosition = this.translateScreenPositionWithSpatialIndex(Point(screenRow, 0), 'forward')
       if (bufferPosition.column === 0) {
-        return screenRow
+        return [bufferPosition.row, screenRow]
       } else {
         const endOfBufferRow = Point(
           bufferPosition.row,

--- a/src/screen-line-builder.js
+++ b/src/screen-line-builder.js
@@ -27,7 +27,8 @@ class ScreenLineBuilder {
     this.bufferRow = this.displayLayer.findBoundaryPrecedingBufferRow(this.bufferRow)
     this.screenRow = this.displayLayer.translateBufferPositionWithSpatialIndex(Point(this.bufferRow, 0)).row
 
-    endScreenRow = this.displayLayer.findBoundaryFollowingScreenRow(endScreenRow)
+    let endBufferRow;
+    ([endBufferRow, endScreenRow] = this.displayLayer.findBoundaryFollowingScreenRow(endScreenRow))
 
     let didSeekDecorationIterator = false
     const decorationIterator = this.displayLayer.buffer.languageMode.buildHighlightIterator()
@@ -81,7 +82,7 @@ class ScreenLineBuilder {
 
       if (!didSeekDecorationIterator || this.compareBufferPosition(decorationIterator.getPosition()) > 0) {
         didSeekDecorationIterator = true
-        this.scopeIdsToReopen = decorationIterator.seek(Point(this.bufferRow, this.bufferColumn))
+        this.scopeIdsToReopen = decorationIterator.seek(Point(this.bufferRow, this.bufferColumn), endBufferRow)
       }
 
       // This loop may visit multiple buffer rows if there are folds and
@@ -93,7 +94,7 @@ class ScreenLineBuilder {
           if (this.displayLayer.isSoftWrapHunk(nextHunk)) {
             this.emitSoftWrap(nextHunk)
           } else {
-            this.emitFold(nextHunk, decorationIterator)
+            this.emitFold(nextHunk, decorationIterator, endBufferRow)
           }
 
           hunkIndex++
@@ -223,7 +224,7 @@ class ScreenLineBuilder {
     }
   }
 
-  emitFold (nextHunk, decorationIterator) {
+  emitFold (nextHunk, decorationIterator, endBufferRow) {
     this.emitCloseTag(this.getBuiltInScopeId(this.currentBuiltInClassNameFlags))
     this.currentBuiltInClassNameFlags = 0
 
@@ -237,7 +238,7 @@ class ScreenLineBuilder {
     this.bufferRow = nextHunk.oldEnd.row
     this.bufferColumn = nextHunk.oldEnd.column
 
-    this.scopeIdsToReopen = decorationIterator.seek(Point(this.bufferRow, this.bufferColumn))
+    this.scopeIdsToReopen = decorationIterator.seek(Point(this.bufferRow, this.bufferColumn), endBufferRow)
 
     this.bufferLine = this.displayLayer.buffer.lineForRow(this.bufferRow)
     this.trailingWhitespaceStartColumn = this.displayLayer.findTrailingWhitespaceStartColumn(this.bufferLine)


### PR DESCRIPTION
For some language mode implementations (e.g. the [TreeSitterLanguageMode](https://github.com/atom/atom/blob/master/src/tree-sitter-language-mode.js)), it's helpful to know how far the decoration iterator is going to need to walk when `seek` is called on the iterator. It allows us to only initialize the state that's really going to be needed.

Luckily, that information is readily at hand. In this PR, I update the `ScreenLineBuilder` to provide the end buffer row when calling `seek`.