### PR TITLE
Add bufferDidFinishTransaction hook to language modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.14.12",
+  "version": "13.15.0-0",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/spec/display-layer-spec.js
+++ b/spec/display-layer-spec.js
@@ -2060,6 +2060,8 @@ describe('DisplayLayer', () => {
             this.didChange = true
           },
 
+          bufferDidFinishTransaction () {},
+
           onDidChangeHighlighting (callback) {
             return this.emitter.on('did-change-highlighting', callback)
           },

--- a/spec/helpers/test-language-mode.js
+++ b/spec/helpers/test-language-mode.js
@@ -50,6 +50,8 @@ class TestLanguageMode {
     this.insertRandomDecorations(oldRange, newRange)
   }
 
+  bufferDidFinishTransaction () {}
+
   emitHighlightingChangeEvent (range) {
     this.emitter.emit('did-change-highlighting', range)
   }

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -165,6 +165,8 @@ describe('TextBuffer IO', () => {
           events.push(['decoration-layer', {oldRange, newRange, oldText, newText}])
         },
 
+        bufferDidFinishTransaction () {},
+
         onDidChangeHighlighting () {
           return {dispose () {}}
         }

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -106,6 +106,7 @@ describe "TextBuffer", ->
         events = []
         languageMode = {
           bufferDidChange: (e) -> events.push({source: 'language-mode', event: e}),
+          bufferDidFinishTransaction: ->,
           onDidChangeHighlighting: -> {dispose: ->}
         }
         displayLayer1 = buffer.addDisplayLayer()

--- a/src/null-language-mode.js
+++ b/src/null-language-mode.js
@@ -6,6 +6,7 @@ const EMPTY = []
 module.exports =
 class NullLanguageMode {
   bufferDidChange () {}
+  bufferDidFinishTransaction () {}
   buildHighlightIterator () { return new NullHighlightIterator() }
   onDidChangeHighlighting () { return new Disposable(() => {}) }
   getLanguageId () { return null }

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -2350,7 +2350,9 @@ class TextBuffer {
         const compactedChanges = patchFromChanges(this.changesSinceLastDidChangeTextEvent).getChanges()
         this.changesSinceLastDidChangeTextEvent.length = 0
         if (compactedChanges.length > 0) {
-          this.emitter.emit('did-change-text', new ChangeEvent(this, compactedChanges))
+          const changeEvent = new ChangeEvent(this, compactedChanges)
+          this.languageMode.bufferDidFinishTransaction(changeEvent)
+          this.emitter.emit('did-change-text', changeEvent)
         }
         this.debouncedEmitDidStopChangingEvent()
         this._emittedWillChangeEvent = false


### PR DESCRIPTION
### Background

Currently, Atom's `TreeSitterLanguageMode` [uses](https://github.com/atom/atom/blob/a384dde3f5978d804306bc2033b7aae8570ceeb2/src/tree-sitter-language-mode.js#L49-L61) the buffer's `onDidChangeText` method to determine when it should re-parse.

The problem with this is that the language mode is not guaranteed to receive that other event before other packages (e.g. [bracket-matcher](https://github.com/atom/bracket-matcher)). In particular, if you *change* a buffer's language mode after a package has started listening to the `onDidChangeText` event, the order will be reversed: the new language mode will receive its text change event *after* the package code.

### Solution

This PR adds a new required hook to language modes: `bufferDidFinishTransaction`. This is basically the same thing as the `onDidChangeText` event, but it's guaranteed to be delivered to the language mode before the `onDidChangeText` event is fired.

### Related Issues

Required for https://github.com/atom/bracket-matcher/pull/367