### PR TITLE
Avoid construction of JS strings representing buffer lines on performance-sensitive code paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mkdirp": "^0.5.1",
     "pathwatcher": "8.0.2",
     "serializable": "^1.0.3",
-    "superstring": "2.3.6",
+    "superstring": "2.4.0",
     "underscore-plus": "^1.0.0"
   },
   "standard": {

--- a/src/display-layer.js
+++ b/src/display-layer.js
@@ -702,15 +702,15 @@ class DisplayLayer {
     return length
   }
 
-  findTrailingWhitespaceStartColumn (lineText) {
-    let column
-    for (column = lineText.length; column >= 0; column--) {
-      const previousCharacter = lineText[column - 1]
+  findTrailingWhitespaceStartColumn (bufferRow) {
+    let position
+    for (position = {row: bufferRow, column: this.buffer.lineLengthForRow(bufferRow) - 1}; position.column >= 0; position.column--) {
+      const previousCharacter = this.buffer.getCharacterAtPosition(position)
       if (previousCharacter !== ' ' && previousCharacter !== '\t') {
         break
       }
     }
-    return column
+    return position.column + 1
   }
 
   registerBuiltInScope (flags, className) {

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -657,6 +657,10 @@ class TextBuffer {
     return this.cachedText
   }
 
+  getCharacterAtPosition (position) {
+    return this.buffer.getCharacterAtPosition(Point.fromObject(position))
+  }
+
   // Public: Get the text in a range.
   //
   // * `range` A {Range}


### PR DESCRIPTION
:pear:d with @rafeca

A long time ago, Atom represented buffers as an array of JS strings, one for each line. We later changed our buffer representation to the native [`superstring`](https://github.com/atom/superstring) library, which represents a buffer's contents by composing layers of changes as `u16string`s in C++. In this new world, lines aren't treated specially in our storage of the text. Calling `TextBuffer.lineForRow` became much more expensive, because it now requires us to construct a new JS string representing the line rather than just returning a reference to an *existing* string from a lines array. This left us with a couple of code paths that performed extremely poorly on files with very long lines.

In this PR, we tackled a couple of those offending code paths.

### Position clipping

When we "clip" positions, we make sure that the cursor is positioned at a valid location in the file. If it's in the middle of two Unicode surrogate pairs or inside of an atomic soft tab, we adjust the position to the nearest valid column in the buffer. Previously, to do this we were operating on the text of the line as a JS string. In this PR, we instead added a `getCharacterAtPosition` method to `superstring` to allow us to instead index directly into the buffer without calling `lineForBufferRow` and constructing a string.

### Screen line construction

Previously, we relied on the raw text of the buffer line when rendering screen lines. Now, we take a similar approach to clipping and index directly into the buffer when constructing screen lines.

### Results

These optimizations will show up in various places, but a good demonstration is moving the cursor inside a 4.5MB file containing just a single line of text.

*Before:* Note the frame time of 369ms to handle the event and update the screen. Also note that `lineForRow` dominates in the top-down profile statistics at the bottom of the frame.

<img width="1440" alt="Screen Shot 2019-06-07 at 11 07 14 AM" src="https://user-images.githubusercontent.com/1789/59121263-dbb60080-8914-11e9-9b0a-90871fce754a.png">

*After:* Now the frame time is 28.3ms. Still not our ideal of < 16ms, but much more reasonable. `lineForRow` does not even register in the profile.

<img width="1530" alt="Screen Shot 2019-06-07 at 11 07 44 AM" src="https://user-images.githubusercontent.com/1789/59121312-00aa7380-8915-11e9-889b-f669ed5ba5e7.png">
