### PR TITLE
Update and use caret for pathwatcher dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 sudo: false
 
-node_js: 8
+node_js: 10
 
 env:
   - CC=clang CXX=clang++

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2015
 
 environment:
-  nodejs_version: "8"
+  nodejs_version: "10"
 
 platform:
   - x86

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fs-plus": "^3.0.0",
     "grim": "^2.0.2",
     "mkdirp": "^0.5.1",
-    "pathwatcher": "8.0.2",
+    "pathwatcher": "^8.1.0",
     "serializable": "^1.0.3",
     "superstring": "2.4.0",
     "underscore-plus": "^1.0.0"


### PR DESCRIPTION
We've recently released `pathwatcher@8.1.0` but `text-buffer` didn't upgrade to it since it depends on a fixed version.

This PR changes the dependency to match any v8.x version of `pathwatcher`, so we don't need to update this package every time we publish a new version.

The caret was removed by https://github.com/atom/text-buffer/commit/fdbe6accc193d13dfb50d4b38193bc1c6fa03626 but it's not linked to any PR and there's no explanation about the motivations of the change, so I'm guessing it should be fine to re-add it.