### PR TITLE
Unable to replace text with special character when the search regex contains a word boundary

### DIFF
--- a/spec/text-buffer-spec.js
+++ b/spec/text-buffer-spec.js
@@ -1,14 +1,14 @@
-const path = require('path');
-const TextBuffer = require ('../src/text-buffer');
+const path = require('path')
+const TextBuffer = require('../src/text-buffer')
 
 describe('when a buffer is already open', () => {
-  it('replaces foo( with bar( using /\bfoo\(\b/gim', () => {
-    const filePath = path.join(__dirname, 'fixtures','sample.js');
-    const buffer = new TextBuffer();
-    buffer.setPath(filePath);
-    buffer.setText('foo(x)');
-    buffer.replace(/\bfoo\(\b/gim,'bar(');
+  it('replaces foo( with bar( using /\bfoo\\(\b/gim', () => {
+    const filePath = path.join(__dirname, 'fixtures', 'sample.js')
+    const buffer = new TextBuffer()
+    buffer.setPath(filePath)
+    buffer.setText('foo(x)')
+    buffer.replace(/\bfoo\(\b/gim, 'bar(')
 
-    expect(buffer.getText()).toBe('bar(x)');
-  });
-});
+    expect(buffer.getText()).toBe('bar(x)')
+  })
+})

--- a/spec/text-buffer-spec.js
+++ b/spec/text-buffer-spec.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const TextBuffer = require ('../src/text-buffer');
+
+describe('when a buffer is already open', () => {
+  it('replaces foo( with bar( using /\bfoo\(\b/gim', () => {
+    const filePath = path.join(__dirname, 'fixtures','sample.js');
+    const buffer = new TextBuffer();
+    buffer.setPath(filePath);
+    buffer.setText('foo(x)');
+    buffer.replace(/\bfoo\(\b/gim,'bar(');
+
+    expect(buffer.getText()).toBe('bar(x)');
+  });
+});

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -1608,8 +1608,8 @@ class TextBuffer {
     let replacements = 0
 
     this.transact(() => {
-      return this.scan(regex, function ({matchText, replace}) {
-        replace(matchText.replace(regex, replacementText))
+      return this.scan(regex, function ({replace}) {
+        replace(replacementText)
         return replacements++
       })
     })


### PR DESCRIPTION
### Description of the Change
Enables texts with special characters to be replaced when search regex contains a word boundary in open file(s) e.g to replace `foo(` with `bar(` in an open file containing `foo(x)` using `/\bfoo\(\b/gim` as the search regex

### Applicable Issues

Fixes the issue in find-and-replace package https://github.com/atom/find-and-replace/issues/1102
