### PR TITLE
Fix Node 12 compilation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 sudo: false
 
-node_js: 10
+node_js: 12
 
 env:
   - CC=clang CXX=clang++

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2015
 
 environment:
-  nodejs_version: "10"
+  nodejs_version: "12"
 
 platform:
   - x86

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-buffer",
-  "version": "13.17.1",
+  "version": "13.17.2",
   "description": "A container for large mutable strings with annotated regions",
   "main": "./lib/text-buffer",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
     "diff": "^2.2.1",
     "emissary": "^1.0.0",
     "event-kit": "^2.4.0",
-    "fs-admin": "^0.5.0",
+    "fs-admin": "^0.12.0",
     "fs-plus": "^3.0.0",
     "grim": "^2.0.2",
     "mkdirp": "^0.5.1",
     "pathwatcher": "^8.1.0",
     "serializable": "^1.0.3",
-    "superstring": "2.4.0",
+    "superstring": "^2.4.2",
     "underscore-plus": "^1.0.0"
   },
   "standard": {


### PR DESCRIPTION
 The following packages were bumped to fix compilation errors on node 12:
- `superstring@2.4.0` to `superstring@2.4.2`
- `fs-admin@0.5.0` to `fs-admin@0.12.0`
------
The CI config was also updated to use `node v12`