### PR TITLE
Fix project-level find-and-replace regex bug

### DIFF
--- a/spec/text-buffer-spec.js
+++ b/spec/text-buffer-spec.js
@@ -24,7 +24,7 @@ describe('when a buffer is already open', () => {
 
     it('replaces atom/flight-manualatomio with $1', () => {
       buffer.setText('atom/flight-manualatomio')
-      buffer.replace($1, '$1')
+      buffer.replace(/\.(atom)\./, '$1')
 
       expect(buffer.getText()).toBe('atom/flight-manualatomio')
     })

--- a/spec/text-buffer-spec.js
+++ b/spec/text-buffer-spec.js
@@ -2,9 +2,10 @@ const path = require('path')
 const TextBuffer = require('../src/text-buffer')
 
 describe('when a buffer is already open', () => {
+  const filePath = path.join(__dirname, 'fixtures', 'sample.js')
+  const buffer = new TextBuffer()
+
   it('replaces foo( with bar( using /\bfoo\\(\b/gim', () => {
-    const filePath = path.join(__dirname, 'fixtures', 'sample.js')
-    const buffer = new TextBuffer()
     buffer.setPath(filePath)
     buffer.setText('foo(x)')
     buffer.replace(/\bfoo\(\b/gim, 'bar(')
@@ -12,13 +13,20 @@ describe('when a buffer is already open', () => {
     expect(buffer.getText()).toBe('bar(x)')
   })
 
-  it('replaces tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit; with tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit);', () => {
-    const filePath = path.join(__dirname, 'fixtures', 'sample.js')
-    const buffer = new TextBuffer()
-    buffer.setPath(filePath)
-    buffer.setText('if (tstat_fvars()->curr_setpoint[HEAT_EN] > new_tptr->heat_limit) { tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit; }')
-    buffer.replace(/tstat_fvars\(\)->curr_setpoint\[(.+?)\] = (.+?);/, 'tstat_set_curr_setpoint($1, $2);')
+  describe('should properly replace regex literals', () => {
+    it('replaces tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit; with tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit);', () => {
+      buffer.setPath(filePath)
+      buffer.setText('tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit;')
+      buffer.replace(/tstat_fvars\(\)->curr_setpoint\[(.+?)\] = (.+?);/, 'tstat_set_curr_setpoint($1, $2);')
 
-    expect(buffer.getText()).toBe('if (tstat_fvars()->curr_setpoint[HEAT_EN] > new_tptr->heat_limit) { tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit); }')
+      expect(buffer.getText()).toBe('tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit);')
+    })
+
+    it('replaces atom/flight-manual.atom.io with atom/flight-manualatomio', () => {
+      buffer.setText('atom/flight-manual.atom.io')
+      buffer.replace(/\.(atom)\./, '$1')
+
+      expect(buffer.getText()).toBe('atom/flight-manualatomio')
+    })
   })
 })

--- a/spec/text-buffer-spec.js
+++ b/spec/text-buffer-spec.js
@@ -13,8 +13,8 @@ describe('when a buffer is already open', () => {
     expect(buffer.getText()).toBe('bar(x)')
   })
 
-  describe('should properly replace regex literals', () => {
-    it('replaces tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit; with tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit);', () => {
+  describe('Texts should be replaced properly with strings containing literals when using the regex option', () => {
+    it('replaces tstat_fvars()->curr_setpoint[HEAT_EN] with tstat_set_curr_setpoint($1, $2);', () => {
       buffer.setPath(filePath)
       buffer.setText('tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit;')
       buffer.replace(/tstat_fvars\(\)->curr_setpoint\[(.+?)\] = (.+?);/, 'tstat_set_curr_setpoint($1, $2);')
@@ -22,9 +22,9 @@ describe('when a buffer is already open', () => {
       expect(buffer.getText()).toBe('tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit);')
     })
 
-    it('replaces atom/flight-manual.atom.io with atom/flight-manualatomio', () => {
-      buffer.setText('atom/flight-manual.atom.io')
-      buffer.replace(/\.(atom)\./, '$1')
+    it('replaces atom/flight-manualatomio with $1', () => {
+      buffer.setText('atom/flight-manualatomio')
+      buffer.replace($1, '$1')
 
       expect(buffer.getText()).toBe('atom/flight-manualatomio')
     })

--- a/spec/text-buffer-spec.js
+++ b/spec/text-buffer-spec.js
@@ -11,4 +11,14 @@ describe('when a buffer is already open', () => {
 
     expect(buffer.getText()).toBe('bar(x)')
   })
+
+  it('replaces tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit; with tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit);', () => {
+    const filePath = path.join(__dirname, 'fixtures', 'sample.js')
+    const buffer = new TextBuffer()
+    buffer.setPath(filePath)
+    buffer.setText('if (tstat_fvars()->curr_setpoint[HEAT_EN] > new_tptr->heat_limit) { tstat_fvars()->curr_setpoint[HEAT_EN] = new_tptr->heat_limit; }')
+    buffer.replace(/tstat_fvars\(\)->curr_setpoint\[(.+?)\] = (.+?);/, 'tstat_set_curr_setpoint($1, $2);')
+
+    expect(buffer.getText()).toBe('if (tstat_fvars()->curr_setpoint[HEAT_EN] > new_tptr->heat_limit) { tstat_set_curr_setpoint(HEAT_EN, new_tptr->heat_limit); }')
+  })
 })

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -1608,7 +1608,9 @@ class TextBuffer {
     let replacements = 0
 
     this.transact(() => {
-      return this.scan(regex, function ({replace}) {
+      return this.scan(regex, function ({matchText, replace}) {
+        const text = matchText.replace(regex, replacementText)
+        replacementText = text === matchText ? replacementText : text
         replace(replacementText)
         return replacements++
       })


### PR DESCRIPTION
### Description of the Change
This PR ensures regex literals are properly replaced during project-level find-and-replace with the regex option selected e.g `atom/flight-manual.atom.io`  is replaced with `atom/flight-manualatomio` instead of `atom/flight-manual1$io`  when the search string is `/\.(atom)\./` and the replacement string is `1$`
### Applicable Issues

Fixes the issue in find-and-replace package  https://github.com/atom/find-and-replace/issues/1110