### PR TITLE
Allow to save hidden files in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "pathwatcher": "^8.1.0",
     "serializable": "^1.0.3",
     "superstring": "^2.4.2",
-    "underscore-plus": "^1.0.0"
+    "underscore-plus": "^1.0.0",
+    "winattr": "^3.0.0"
   },
   "standard": {
     "env": {

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -1927,13 +1927,28 @@ class TextBuffer {
       try {
         await this.buffer.save(destination, this.getEncoding())
       } catch (error) {
-        const canEscalate = process.platform === 'darwin' || process.platform === 'linux'
-        if (error.code === 'EACCES' && destination === filePath && canEscalate) {
-          const fsAdmin = require('fs-admin')
-          try {
-            await this.buffer.save(fsAdmin.createWriteStream(filePath), this.getEncoding())
-          } catch (_) {
-            throw error
+        const isMacOrLinux = process.platform === 'darwin' || process.platform === 'linux'
+        const isWindows = process.platform === 'win32'
+        if (error.code === 'EACCES' && destination === filePath) {
+          if (isMacOrLinux) {
+            const fsAdmin = require('fs-admin')
+            try {
+              await this.buffer.save(fsAdmin.createWriteStream(filePath), this.getEncoding())
+            } catch (_) {
+              throw error
+            }
+          } else if (isWindows) {
+            const winattr = require('winattr')
+            const attrs = winattr.getSync(filePath)
+            if (!attrs.hidden) throw error
+
+            try {
+              winattr.setSync(filePath, { hidden: false })
+              await this.buffer.save(filePath, this.getEncoding())
+              winattr.setSync(filePath, { hidden: true })
+            } catch (_) {
+              throw error
+            }
           }
         } else {
           throw error

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -1929,16 +1929,8 @@ class TextBuffer {
       } catch (error) {
         if (error.code !== 'EACCES' || destination !== filePath) throw error
 
-        const isMacOrLinux = process.platform === 'darwin' || process.platform === 'linux'
         const isWindows = process.platform === 'win32'
-        if (isMacOrLinux) {
-          const fsAdmin = require('fs-admin')
-          try {
-            await this.buffer.save(fsAdmin.createWriteStream(filePath), this.getEncoding())
-          } catch (_) {
-            throw error
-          }
-        } else if (isWindows) {
+        if (isWindows) {
           const winattr = getPromisifiedWinattr()
           const attrs = await winattr.get(filePath)
           if (!attrs.hidden) throw error
@@ -1947,6 +1939,13 @@ class TextBuffer {
             await winattr.set(filePath, { hidden: false })
             await this.buffer.save(filePath, this.getEncoding())
             await winattr.set(filePath, { hidden: true })
+          } catch (_) {
+            throw error
+          }
+        } else {
+          const fsAdmin = require('fs-admin')
+          try {
+            await this.buffer.save(fsAdmin.createWriteStream(filePath), this.getEncoding())
           } catch (_) {
             throw error
           }


### PR DESCRIPTION
### Identify the Bug

This PR addresses https://github.com/atom/atom/issues/13538

### Description of the Change

Trying to save a hidden file in Windows will raise a permission error. This PR uses [winattr](https://www.npmjs.com/package/winattr) to bypass that issue by toggling the hidden attribute to false while saving, and then turning it back on when done.

### Alternate Designs

I do introduce a dependency (winattr) as there's no easy way to handle attributes for files in Windows using Node.js. Alternatively, it could be written by hand, but it's a lot of tests and code that is better delegated to it's own library. Winattr is quite popular and stable so I think it's by far the best option.

### Possible Drawbacks

--

### Verification Process

I tried it locally on my Windows 10 installation and it worked. I also added tests and they passed.

### Release Notes

TextBuffer is now able to save hidden files in Windows