### PR TITLE
Bump winattr to @aminya/winattr@4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "serializable": "^1.0.3",
     "superstring": "^2.4.4",
     "underscore-plus": "^1.0.0",
-    "winattr": "^3.0.0"
+    "winattr": "npm:@aminya/winattr@^4.0.3"
   },
   "standard": {
     "env": {

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -1931,7 +1931,7 @@ class TextBuffer {
 
         const isWindows = process.platform === 'win32'
         if (isWindows) {
-          const winattr = getPromisifiedWinattr()
+          const winattr = require('winattr')
           const attrs = await winattr.get(filePath)
           if (!attrs.hidden) throw error
 
@@ -2611,20 +2611,6 @@ class SearchCallbackArgument {
   stop () {
     this.stopped = true
   }
-}
-
-let _winattr = null
-const getPromisifiedWinattr = function () {
-  if (_winattr === null) {
-    const { promisify } = require('util')
-    const winattr = require('winattr')
-    _winattr = {
-      set: promisify(winattr.set),
-      get: promisify(winattr.get)
-    }
-  }
-
-  return _winattr
 }
 
 module.exports = TextBuffer


### PR DESCRIPTION
### Description of the change

This replaces winattr with the promisified version which is registered under my name. 
https://github.com/aminya/winattr

This also bumps fswin, which may solve the issue of fswin.node in Linux/MacOS for Electron upgrade.  https://github.com/atom/atom/pull/21777

### Benefits
- Promisifed 
- fswin bumped

### Verification 
Tests pass

